### PR TITLE
Reference documentation link fix

### DIFF
--- a/docs/src/docbkx/reference/bootstrap.xml
+++ b/docs/src/docbkx/reference/bootstrap.xml
@@ -6,7 +6,7 @@
 
   <para>One of the first tasks when using GemFire and Spring is to configure
   the data grid through the IoC container. While this is <ulink
-  url="http://community.gemstone.com/display/gemfire/Integrating+GemFire+with+the+Spring+IoC+Container">possible</ulink>
+  url="http://community.gemstone.com/display/gemfire60/Integrating+GemFire+with+the+Spring+IoC+Container">possible</ulink>
   out of the box, the configuration tends to be verbose and only address basic
   cases. To address this problem, the Spring GemFire project provides several
   classes that enable the configuration of distributed caches or regions to


### PR DESCRIPTION
The link in documentation is broken:
http://static.springsource.org/spring-gemfire/docs/current/reference/html-single/#bootstrap

Second sentence in paragraph stating: "While this is possible out of the box,..."
 "possible" points to "Page Not Found".

Should probably link to:
http://community.gemstone.com/display/gemfire60/Integrating+GemFire+with+the+Spring+IoC+Container

instead of:
http://community.gemstone.com/display/gemfire/Integrating+GemFire+with+the+Spring+IoC+Container
