### PR TITLE
SGF-71 Add receive-values Attribute to Client Region

### DIFF
--- a/docs/src/reference/docbook/reference/bootstrap.xml
+++ b/docs/src/reference/docbook/reference/bootstrap.xml
@@ -580,11 +580,19 @@ redundancy. Each copy provides extra backup at the expense of extra storages.</e
 			key-based and regular-expression-based types being supported; for example:</para>
 			
 			<programlisting language="xml"><![CDATA[<gfe:client-region id="complex" pool-name="gemfire-pool">
-    <gfe:key-interest durable="true" result-policy="KEYS">
-        <bean id="key" class="java.lang.String"/>
+    <gfe:key-interest durable="true" result-policy="KEYS" receive-values="true">
+        <bean class="java.lang.String">
+            <constructor-arg value="myKey"/>
+        </bean>
     </gfe:key-interest>
-    <gfe:regex-interest pattern=".*"/>
+    <gfe:regex-interest pattern=".*" receive-values="false"/>
 </gfe:client-region>]]></programlisting>
+
+		<para>A special key 'ALL_KEYS' means interest is registered for all keys (identical to
+		a regex interest of '.*').</para>
+		<para>The 'receive-values' attribute indicates whether or not the values are received
+		for create and update events. When true, values are received; when false, only 
+		invalidation events are received.</para>
 		</section>
 	</section>
 

--- a/src/main/java/org/springframework/data/gemfire/client/ClientRegionFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/client/ClientRegionFactoryBean.java
@@ -43,6 +43,7 @@ import com.gemstone.gemfire.cache.client.Pool;
  * Client extension for GemFire regions.
  * 
  * @author Costin Leau
+ * @author Gary Russell
  */
 public class ClientRegionFactoryBean<K, V> extends RegionLookupFactoryBean<K, V> implements BeanFactoryAware,
 		DisposableBean {
@@ -153,10 +154,14 @@ public class ClientRegionFactoryBean<K, V> extends RegionLookupFactoryBean<K, V>
 			for (Interest<K> interest : interests) {
 				if (interest instanceof RegexInterest) {
 					// do the cast since it's safe
-					region.registerInterestRegex((String) interest.getKey(), interest.getPolicy(), interest.isDurable());
+					region.registerInterestRegex((String) interest.getKey(),
+							interest.getPolicy(), interest.isDurable(),
+							interest.isReceiveValues());
 				}
 				else {
-					region.registerInterest(interest.getKey(), interest.getPolicy(), interest.isDurable());
+					region.registerInterest(interest.getKey(),
+							interest.getPolicy(), interest.isDurable(),
+							interest.isReceiveValues());
 				}
 			}
 		}

--- a/src/main/java/org/springframework/data/gemfire/client/Interest.java
+++ b/src/main/java/org/springframework/data/gemfire/client/Interest.java
@@ -27,6 +27,7 @@ import com.gemstone.gemfire.cache.InterestResultPolicy;
  * and or JavaBeans means.
  * 
  * @author Costin Leau
+ * @author Gary Russell
  */
 public class Interest<K> implements InitializingBean {
 
@@ -35,33 +36,40 @@ public class Interest<K> implements InitializingBean {
 	private K key;
 	private InterestResultPolicy policy = InterestResultPolicy.DEFAULT;
 	private boolean durable = false;
+	private boolean receiveValues = false;
 
 	public Interest() {
 	}
 
 	public Interest(K key) {
-		this(key, InterestResultPolicy.DEFAULT, false);
+		this(key, InterestResultPolicy.DEFAULT, false, false);
 	}
 
 	public Interest(K key, InterestResultPolicy policy) {
-		this(key, policy, false);
+		this(key, policy, false, false);
 	}
 
 	public Interest(K key, String policy) {
-		this(key, policy, false);
+		this(key, policy, false, false);
 	}
 
 	public Interest(K key, String policy, boolean durable) {
+		this(key, policy, durable, false);
+	}
+
+	public Interest(K key, String policy, boolean durable, boolean receiveValues) {
 		this.key = key;
 		this.policy = (InterestResultPolicy) constants.asObject(policy);
 		this.durable = durable;
+		this.receiveValues = receiveValues;
 		afterPropertiesSet();
 	}
 
-	public Interest(K key, InterestResultPolicy policy, boolean durable) {
+	public Interest(K key, InterestResultPolicy policy, boolean durable, boolean receiveValues) {
 		this.key = key;
 		this.policy = policy;
 		this.durable = durable;
+		this.receiveValues = receiveValues;
 		afterPropertiesSet();
 	}
 
@@ -134,5 +142,23 @@ public class Interest<K> implements InitializingBean {
 	 */
 	public void setDurable(boolean durable) {
 		this.durable = durable;
+	}
+
+	/**
+	 * Returns whether values are returned in events.
+	 *
+	 * @return the receiveValues
+	 */
+	protected boolean isReceiveValues() {
+		return receiveValues;
+	}
+
+	/**
+	 * Sets whether values are returned in events.
+	 *
+	 * @param receiveValues the receiveValues to set
+	 */
+	public void setReceiveValues(boolean receiveValues) {
+		this.receiveValues = receiveValues;
 	}
 }

--- a/src/main/java/org/springframework/data/gemfire/config/ClientRegionParser.java
+++ b/src/main/java/org/springframework/data/gemfire/config/ClientRegionParser.java
@@ -145,5 +145,6 @@ class ClientRegionParser extends AliasReplacingBeanDefinitionParser {
 	private void parseCommonInterestAttr(Element element, BeanDefinitionBuilder builder) {
 		ParsingUtils.setPropertyValue(element, builder, "durable", "durable");
 		ParsingUtils.setPropertyValue(element, builder, "result-policy", "policy");
+		ParsingUtils.setPropertyValue(element, builder, "receive-values", "receiveValues");
 	}
 }

--- a/src/main/resources/org/springframework/data/gemfire/config/spring-gemfire-1.1.xsd
+++ b/src/main/resources/org/springframework/data/gemfire/config/spring-gemfire-1.1.xsd
@@ -911,6 +911,15 @@ NONE -  Does not initialize the local cache.
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:attribute>
+		<xsd:attribute name="receive-values" default="true" use="optional" type="xsd:boolean">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+If set to true (default), values are received with create and update events on keys of interest.
+If set to false, only invalidations are received and the value will be received on the next get
+instead.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:complexType>
 	
 	<xsd:element name="pool">


### PR DESCRIPTION
Receive values (default true) determines whether values are
received by the client cache when a server create or update
event is received. When false, only invalidation events are
received.
