### PR TITLE
SGF-112 - Rejecting repository interfaces and methods using pagination.

### DIFF
--- a/src/main/java/org/springframework/data/gemfire/repository/query/GemfireQueryMethod.java
+++ b/src/main/java/org/springframework/data/gemfire/repository/query/GemfireQueryMethod.java
@@ -18,6 +18,7 @@ package org.springframework.data.gemfire.repository.query;
 import java.lang.reflect.Method;
 
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.gemfire.mapping.GemfirePersistentEntity;
 import org.springframework.data.gemfire.mapping.GemfirePersistentProperty;
 import org.springframework.data.gemfire.repository.Query;
@@ -50,6 +51,13 @@ public class GemfireQueryMethod extends QueryMethod {
 		super(method, metadata);
 
 		Assert.notNull(context);
+
+		for (Class<?> type : method.getParameterTypes()) {
+			if (Pageable.class.isAssignableFrom(type)) {
+				throw new IllegalStateException("Pagination is not supported by Gemfire repositories! Offending method: "
+						+ method.toString());
+			}
+		}
 
 		this.method = method;
 		this.entity = context.getPersistentEntity(getDomainClass());

--- a/src/test/java/org/springframework/data/gemfire/repository/query/GemfireQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/gemfire/repository/query/GemfireQueryMethodUnitTests.java
@@ -21,17 +21,21 @@ import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.gemfire.mapping.GemfireMappingContext;
 import org.springframework.data.gemfire.repository.Query;
 import org.springframework.data.gemfire.repository.sample.Person;
 import org.springframework.data.repository.core.RepositoryMetadata;
 
 /**
+ * Unit tests for {@link GemfireQueryMethod}.
  * 
  * @author Oliver Gierke
  */
@@ -62,6 +66,23 @@ public class GemfireQueryMethodUnitTests {
 		assertThat(method.getAnnotatedQuery(), is(nullValue()));
 	}
 
+	/**
+	 * @see SGF-112
+	 */
+	@Test
+	public void rejectsQueryMethodWithPageableParameter() throws Exception {
+
+		GemfireMappingContext context = new GemfireMappingContext();
+		Method method = Invalid.class.getMethod("someMethod", Pageable.class);
+
+		try {
+			new GemfireQueryMethod(method, metadata, context);
+			fail("Expected exception!");
+		} catch (IllegalStateException e) {
+			assertThat(e.getMessage(), Matchers.startsWith("Pagination is not supported by Gemfire repositories!"));
+		}
+	}
+
 	interface Sample {
 
 		@Query("foo")
@@ -71,5 +92,10 @@ public class GemfireQueryMethodUnitTests {
 		void annotatedButEmpty();
 
 		void notAnnotated();
+	}
+
+	interface Invalid {
+
+		Page<?> someMethod(Pageable pageable);
 	}
 }

--- a/src/test/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactoryUnitTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.gemfire.repository.support;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.gemfire.mapping.GemfireMappingContext;
+import org.springframework.data.gemfire.repository.sample.Person;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+import com.gemstone.gemfire.cache.Region;
+import com.gemstone.gemfire.cache.RegionAttributes;
+
+/**
+ * Unit tests for {@link GemfireRepositoryFactory}.
+ * 
+ * @author Oliver Gierke
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GemfireRepositoryFactoryUnitTests {
+
+	@Mock
+	Region<?, ?> region;
+
+	@Mock
+	@SuppressWarnings("rawtypes")
+	RegionAttributes attributes;
+
+	/**
+	 * @see SGF-112
+	 */
+	@Test
+	@SuppressWarnings("unchecked")
+	public void rejectsInterfacesExtendingPagingAndSortingRepository() {
+
+		when(region.getName()).thenReturn("simple");
+		when(region.getAttributes()).thenReturn(attributes);
+
+		List<Region<?, ?>> regions = new ArrayList<Region<?, ?>>();
+		regions.add(region);
+
+		GemfireMappingContext context = new GemfireMappingContext();
+
+		GemfireRepositoryFactory factory = new GemfireRepositoryFactory(regions, context);
+
+		try {
+			factory.getRepository(SampleInterface.class);
+		} catch (IllegalStateException e) {
+			assertThat(e.getMessage(), Matchers.startsWith("Pagination is not supported by Gemfire repositories!"));
+		}
+	}
+
+	interface SampleInterface extends PagingAndSortingRepository<Person, Long> {
+
+	}
+}


### PR DESCRIPTION
Extended GemfireQueryMethod to reject methods that contain a Pageable parameter as we currently don't support pagination.
