### PR TITLE
SGF-113 - Added support to return single entities from query methods.

### DIFF
--- a/src/test/java/org/springframework/data/gemfire/repository/sample/PersonRepository.java
+++ b/src/test/java/org/springframework/data/gemfire/repository/sample/PersonRepository.java
@@ -42,4 +42,6 @@ public interface PersonRepository extends CrudRepository<Person, Long> {
 	Collection<Person> findByFirstnameAndLastname(String firstname, String lastname);
 
 	Collection<Person> findByFirstnameOrLastname(String firstname, String lastname);
+
+	Person findByLastname(String lastname);
 }

--- a/src/test/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactoryIntegrationTests.java
@@ -38,7 +38,7 @@ public class GemfireRepositoryFactoryIntegrationTests extends AbstractGemfireRep
 	}
 
 	@Test(expected = IllegalStateException.class)
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void throwsExceptionIfReferencedRegionIsNotConfigured() {
 
 		GemfireRepositoryFactory factory = new GemfireRepositoryFactory((Iterable) Collections.emptySet(), null);


### PR DESCRIPTION
If a query method returns a single entity it is now correctly unwrapped from the result collection returned by the query. No entities being found will result in `null` returned, more than one entity being found results in an `IncorrectResultSizeDataAccessException` to align with the other repository implementations.
