### PR TITLE
synchronize region lookup to avoid race conditions

### DIFF
--- a/src/main/java/org/springframework/data/gemfire/RegionLookupFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/RegionLookupFactoryBean.java
@@ -50,13 +50,15 @@ public class RegionLookupFactoryBean<K, V> implements FactoryBean<Region<K, V>>,
 		name = (!StringUtils.hasText(name) ? beanName : name);
 		Assert.hasText(name, "Name (or beanName) property must be set");
 
-		region = cache.getRegion(name);
-		if (region != null) {
-			log.info("Retrieved region [" + name + "] from cache");
-		}
+		synchronized (cache) {
+			region = cache.getRegion(name);
+			if (region != null) {
+				log.info("Retrieved region [" + name + "] from cache");
+			}
 
-		else {
-			region = lookupFallback(cache, name);
+			else {
+				region = lookupFallback(cache, name);
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolves the race condition when multiple webapps in a container are deployed in parallel and attempt to lookup a region in shared cache. Without the synchronized block, 2 or more threads may get a null region and attempt to create it.
