### PR TITLE
Fixed JIRA issue SGF-195 concerning colocated Regions in GemFire configu...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ description = 'Spring Data GemFire'
 group = 'org.springframework.data'
 
 repositories {
+  mavenLocal()
   maven { url "http://repo.springsource.org/libs-snapshot" }
   maven { url "http://repo.springsource.org/plugins-release"}
   maven { url "http://dist.gemstone.com.s3.amazonaws.com/maven/release"}

--- a/src/main/java/org/springframework/data/gemfire/PartitionAttributesFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/PartitionAttributesFactoryBean.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.InitializingBean;
 import com.gemstone.gemfire.cache.FixedPartitionAttributes;
 import com.gemstone.gemfire.cache.PartitionAttributes;
 import com.gemstone.gemfire.cache.PartitionResolver;
+import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.partition.PartitionListener;
 
 /**
@@ -33,8 +34,9 @@ import com.gemstone.gemfire.cache.partition.PartitionListener;
  * 
  * @author Costin Leau
  * @author David Turanski
+ * @author John Blum
  */
-@SuppressWarnings({ "unchecked", "rawtypes" })
+@SuppressWarnings({ "unused", "unchecked", "rawtypes" })
 public class PartitionAttributesFactoryBean implements FactoryBean<PartitionAttributes>, InitializingBean {
 
 	private final com.gemstone.gemfire.cache.PartitionAttributesFactory paf = new com.gemstone.gemfire.cache.PartitionAttributesFactory();
@@ -56,8 +58,8 @@ public class PartitionAttributesFactoryBean implements FactoryBean<PartitionAttr
 		return false;
 	}
 
-	public void setColocatedWith(String colocatedRegionFullPath) {
-		paf.setColocatedWith(colocatedRegionFullPath);
+	public void setColocatedWith(Region colocatedWithRegion) {
+		paf.setColocatedWith(colocatedWithRegion.getName());
 	}
 
 	public void setFixedPartitionAttributes(List<FixedPartitionAttributes> fixedPartitionAttributes) {
@@ -105,6 +107,6 @@ public class PartitionAttributesFactoryBean implements FactoryBean<PartitionAttr
 				paf.addPartitionListener(listener);
 			}
 		}
-
 	}
+
 }

--- a/src/main/java/org/springframework/data/gemfire/config/PartitionedRegionParser.java
+++ b/src/main/java/org/springframework/data/gemfire/config/PartitionedRegionParser.java
@@ -25,12 +25,9 @@ import org.springframework.data.gemfire.FixedPartitionAttributesFactoryBean;
 import org.springframework.data.gemfire.PartitionAttributesFactoryBean;
 import org.springframework.data.gemfire.PartitionedRegionFactoryBean;
 import org.springframework.data.gemfire.RegionAttributesFactoryBean;
-import org.springframework.util.StringUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
-
-import com.gemstone.gemfire.management.internal.cli.parser.ParserUtils;
 
 /**
  * Parser for &lt;partitioned-region;gt; definitions.
@@ -40,6 +37,7 @@ import com.gemstone.gemfire.management.internal.cli.parser.ParserUtils;
  * 
  * @author Costin Leau
  * @author David Turanski
+ * @author John Blum
  */
 class PartitionedRegionParser extends AbstractRegionParser {
 	@Override
@@ -57,19 +55,19 @@ class PartitionedRegionParser extends AbstractRegionParser {
 				.genericBeanDefinition(RegionAttributesFactoryBean.class);
 
 		super.doParseCommonRegionConfiguration(element, parserContext, builder, attrBuilder, subRegion);
-		//
+
 		// partition attributes
 		BeanDefinitionBuilder parAttrBuilder = BeanDefinitionBuilder
 				.genericBeanDefinition(PartitionAttributesFactoryBean.class);
-		
-		ParsingUtils.setPropertyValue(element, parAttrBuilder, "colocated-with");
+
+		ParsingUtils.setPropertyReference(element, parAttrBuilder, "colocated-with-ref", "colocatedWith");
 		ParsingUtils.setPropertyValue(element, parAttrBuilder, "local-max-memory");
 		ParsingUtils.setPropertyValue(element, parAttrBuilder, "copies","redundantCopies");
 		ParsingUtils.setPropertyValue(element, parAttrBuilder, "recovery-delay");
 		ParsingUtils.setPropertyValue(element, parAttrBuilder, "startup-recovery-delay");
 		ParsingUtils.setPropertyValue(element, parAttrBuilder, "total-max-memory");
 		ParsingUtils.setPropertyValue(element, parAttrBuilder, "total-buckets","totalNumBuckets");
-		//
+
 		Element subElement = DomUtils.getChildElementByTagName(element, "partition-resolver");
 		// parse nested partition resolver element
 		if (subElement != null) {

--- a/src/main/resources/org/springframework/data/gemfire/config/spring-gemfire-1.3.xsd
+++ b/src/main/resources/org/springframework/data/gemfire/config/spring-gemfire-1.3.xsd
@@ -1275,11 +1275,10 @@ redundancy. Each copy provides extra backup at the expense of extra storages.
 						</xsd:restriction>
 					</xsd:simpleType>
 				</xsd:attribute>
-				<xsd:attribute name="colocated-with" type="xsd:string"
-					use="optional">
+				<xsd:attribute name="colocated-with-ref" type="xsd:string" use="optional">
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
-The name of the partitioned region with which this newly created partitioned region is colocated.
+The ID of the partitioned region with which this newly created partitioned region is colocated.
 							]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>

--- a/src/test/java/org/springframework/data/gemfire/ColocatedRegionIntegrationTest.java
+++ b/src/test/java/org/springframework/data/gemfire/ColocatedRegionIntegrationTest.java
@@ -1,0 +1,52 @@
+package org.springframework.data.gemfire;
+
+import static org.junit.Assert.*;
+
+import javax.annotation.Resource;
+
+import com.gemstone.gemfire.cache.Region;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * The ColocatedRegionIntegrationTest class is a test suite class containing test cases for JIRA issue SGF-195,
+ * concerning colocated Regions in GemFire.
+ * <p/>
+ * @author John Blum
+ * @link https://jira.springsource.org/browse/SGF-195
+ * @see org.junit.Test
+ * @see org.junit.runner.RunWith
+ * @see org.springframework.test.context.ContextConfiguration
+ * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+ * @since 1.3.2
+ */
+@ContextConfiguration("/org/springframework/data/gemfire/colocated-region.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
+@SuppressWarnings("unused")
+public class ColocatedRegionIntegrationTest {
+
+	@Resource(name = "colocatedRegion")
+	private Region colocatedRegion;
+
+	@Resource(name = "sourceRegion")
+	private Region sourceRegion;
+
+	protected static void assertRegionExists(final String expectedRegionName, final Region region) {
+		assertNotNull(region);
+		assertEquals(String.format("Expected Region with name %1$s; but was %2$s!",
+			expectedRegionName, region.getName()), expectedRegionName, region.getName());
+	}
+
+	@Test
+	public void testRegionsColocated() {
+		assertRegionExists("Source", sourceRegion);
+		assertRegionExists("Colocated", colocatedRegion);
+		assertNotNull(colocatedRegion.getAttributes());
+		assertNotNull(colocatedRegion.getAttributes().getPartitionAttributes());
+		assertEquals(sourceRegion.getName(), colocatedRegion.getAttributes().getPartitionAttributes().getColocatedWith());
+	}
+
+}

--- a/src/test/java/org/springframework/data/gemfire/PartitionAttributesFactoryBeanTest.java
+++ b/src/test/java/org/springframework/data/gemfire/PartitionAttributesFactoryBeanTest.java
@@ -1,0 +1,67 @@
+package org.springframework.data.gemfire;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.gemstone.gemfire.cache.PartitionAttributes;
+import com.gemstone.gemfire.cache.PartitionResolver;
+import com.gemstone.gemfire.cache.Region;
+
+import org.junit.Test;
+import org.springframework.data.gemfire.test.MockRegionFactory;
+import org.springframework.data.gemfire.test.StubCache;
+
+/**
+ * The PartitionAttributesFactoryBeanTest class is test suite of test cases testing the contract and functionality of
+ * the PartitionAttributesFactoryBean class.
+ * <p/>
+ * @author John Blum
+ * @see org.springframework.data.gemfire.PartitionAttributesFactoryBean
+ * @see org.junit.Test
+ * @since 1.3.2
+ */
+@SuppressWarnings("unused")
+public class PartitionAttributesFactoryBeanTest {
+
+	private final MockRegionFactory regionFactory = new MockRegionFactory(new StubCache());
+
+	protected Region createMockRegion(final String name) {
+		return regionFactory.mockRegion(name);
+	}
+
+	protected PartitionResolver createMockPartitionResolver(final String name) {
+		PartitionResolver partitionResolver = mock(PartitionResolver.class);
+
+		when(partitionResolver.getName()).thenReturn(name);
+
+		return partitionResolver;
+	}
+
+	@Test
+	public void testSetBasicProperties() throws Exception {
+		PartitionAttributesFactoryBean partitionAttributesFactoryBean = new PartitionAttributesFactoryBean();
+
+		partitionAttributesFactoryBean.setColocatedWith(createMockRegion("mockColocatedRegion"));
+		partitionAttributesFactoryBean.setLocalMaxMemory(1024);
+		partitionAttributesFactoryBean.setPartitionResolver(createMockPartitionResolver("mockPartitionResolver"));
+		partitionAttributesFactoryBean.setRecoveryDelay(1000l);
+		partitionAttributesFactoryBean.setRedundantCopies(1);
+		partitionAttributesFactoryBean.setStartupRecoveryDelay(60000l);
+		partitionAttributesFactoryBean.setTotalMaxMemory(8192l);
+		partitionAttributesFactoryBean.setTotalNumBuckets(42);
+
+		PartitionAttributes partitionAttributes = partitionAttributesFactoryBean.getObject();
+
+		assertNotNull(partitionAttributes);
+		assertEquals("mockColocatedRegion", partitionAttributes.getColocatedWith());
+		assertEquals(1024, partitionAttributes.getLocalMaxMemory());
+		assertNotNull(partitionAttributes.getPartitionResolver());
+		assertEquals("mockPartitionResolver", partitionAttributes.getPartitionResolver().getName());
+		assertEquals(1000l, partitionAttributes.getRecoveryDelay());
+		assertEquals(1, partitionAttributes.getRedundantCopies());
+		assertEquals(60000l, partitionAttributes.getStartupRecoveryDelay());
+		assertEquals(8192l, partitionAttributes.getTotalMaxMemory());
+		assertEquals(42, partitionAttributes.getTotalNumBuckets());
+	}
+
+}

--- a/src/test/resources/org/springframework/data/gemfire/colocated-region.xml
+++ b/src/test/resources/org/springframework/data/gemfire/colocated-region.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire-1.3.xsd">
+
+	<gfe:cache/>
+
+	<!-- NOTE the order of Region bean definitions is important in reproducing the issue in JIRA 195 -->
+	<gfe:partitioned-region id="colocatedRegion" name="Colocated" colocated-with-ref="sourceRegion"/>
+	<gfe:partitioned-region id="sourceRegion" name="Source"/>
+
+</beans>


### PR DESCRIPTION
Fixed JIRA issue SGF-195 concerning colocated Regions in GemFire configured with SDG.

Technically, I was looking to fix this issue by adding a dependency on the PartitionedRegion to which the currently parsed PartitionedRegion (gfe:partitioned-region element with the colocated-with attribute) will be colocated with like so...

```
    String colocatedWithBeanName = element.getAttribute("colocated-with");

    if (StringUtils.hasText(colocatedWithBeanName)) {
        builder.addDependsOn(colocatedWithBeanName);
    }
```

This code snippet would be placed in the PartitionedRegionParser.doParseRegion method.  The advantage of this approach is that the spring-gemfire.xsd XML namespace configuration would not have to change (e.g. colocated-with -> colocated-with-ref).  However, the top-level bean definitions for Regions (replicate, partitioned, etc) do not set the name attribute as additional bean names along with the ID attribute unlike SubRegions.

I was a bit mixed on approach, but ultimately decided in favor of renaming the colocated-with attributed as this would be consistent with the disk-store-ref attribute on the baseReadOnlyRegionType.
