### PR TITLE
Rewrote Subregion parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 target
 bin
 build
+out
 .gradle
 .springBeans
 pom.xml

--- a/src/main/java/org/springframework/data/gemfire/SubRegionFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/SubRegionFactoryBean.java
@@ -60,7 +60,7 @@ public class SubRegionFactoryBean<K, V> extends AttributesFactory<K, V> implemen
 						+ parent.getRegionService());
 			}
 			else {
-				log.debug("creating subregion of [" + parent.getFullPath() + "] with name " + regionName);
+				log.debug("creating subregion of [" + ( parent.getFullPath() == null ? parent.getName() : parent.getFullPath()) + "] with name " + regionName);
 				this.subRegion = this.parent.createSubregion(regionName, create());
 			}
 		}
@@ -86,7 +86,7 @@ public class SubRegionFactoryBean<K, V> extends AttributesFactory<K, V> implemen
 	 * @param name
 	 */
 	public void setName(String name) {
-		this.name = name;
+        this.name = name;
 	}
 
 	/**
@@ -102,7 +102,7 @@ public class SubRegionFactoryBean<K, V> extends AttributesFactory<K, V> implemen
 	 * @param parent
 	 */
 	public void setParent(Region<?, ?> parent) {
-		this.parent = parent;
+        this.parent = parent;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/gemfire/config/LookupRegionParser.java
+++ b/src/main/java/org/springframework/data/gemfire/config/LookupRegionParser.java
@@ -27,7 +27,7 @@ import org.w3c.dom.Element;
 
 /**
  * Parser for &lt;lookup-region;gt; definitions.
- * 
+ *
  * @author Costin Leau
  * @author David Turanski
  */
@@ -47,15 +47,6 @@ class LookupRegionParser extends AbstractRegionParser {
 		}
 		else {
 			builder.addPropertyValue("lookupOnly", true);
-		}
-
-		// parse nested elements
-		List<Element> subElements = DomUtils.getChildElements(element);
-		for (Element subElement : subElements) {
-			String name = subElement.getLocalName();
-			if (name.endsWith("region")) {
-				doParseSubRegion(element, subElement, parserContext, builder, subRegion);
-			}
 		}
 	}
 

--- a/src/test/java/org/springframework/data/gemfire/config/SubRegionNamespaceTest.java
+++ b/src/test/java/org/springframework/data/gemfire/config/SubRegionNamespaceTest.java
@@ -47,12 +47,21 @@ public class SubRegionNamespaceTest {
 	@Autowired
 	private ApplicationContext context;
 
-	
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void testNestedRegionsCreated() {
+        Cache cache = context.getBean(Cache.class);
+        assertNotNull(cache.getRegion("parent"));
+        assertNotNull(cache.getRegion("/parent/child"));
+        assertNotNull(cache.getRegion("/parent/child/grandchild"));
+    }
 
 	@SuppressWarnings("rawtypes")
 	@Test
 	public void testNestedReplicatedRegions() {
-		Region parent = context.getBean("parent", Region.class);
+        Region parent = null;
+		parent = context.getBean("parent", Region.class);
+        Cache cache = context.getBean(Cache.class);
 		Region child = context.getBean("/parent/child", Region.class);
 		Region grandchild = context.getBean("/parent/child/grandchild", Region.class);
 		assertNotNull(child);
@@ -70,15 +79,13 @@ public class SubRegionNamespaceTest {
 		Cache cache = context.getBean(Cache.class);
 
 		Region parent = context.getBean("replicatedParent", Region.class);
-		parent.createSubregion("lookupChild", new AttributesFactory().create());
 
-		Region child = context.getBean("/replicatedParent/lookupChild", Region.class);
-		Region grandchild = context.getBean("/replicatedParent/lookupChild/partitionedGrandchild", Region.class);
+		Region child = context.getBean("/replicatedParent/replicatedChild", Region.class);
+		Region grandchild = context.getBean("/replicatedParent/replicatedChild/partitionedGrandchild", Region.class);
 		assertNotNull(child);
-		assertEquals("/replicatedParent/lookupChild", child.getFullPath());
-		assertSame(child, parent.getSubregion("lookupChild"));
+		assertEquals("/replicatedParent/replicatedChild", child.getFullPath());
 
-		assertEquals("/replicatedParent/lookupChild/partitionedGrandchild", grandchild.getFullPath());
+		assertEquals("/replicatedParent/replicatedChild/partitionedGrandchild", grandchild.getFullPath());
 		assertSame(grandchild, child.getSubregion("partitionedGrandchild"));
 
 	}

--- a/src/test/resources/org/springframework/data/gemfire/config/subregion-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/subregion-ns.xml
@@ -6,22 +6,22 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xsi:schemaLocation="http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd" default-lazy-init="true">
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd" >
 	<gfe:cache />
-    
+
     <gfe:replicated-region id="parent">
         <gfe:replicated-region name="child">
-            <gfe:replicated-region name="grandchild"/> 
+            <gfe:replicated-region name="grandchild"/>
         </gfe:replicated-region>
     </gfe:replicated-region>
-    
-    
+
+
      <gfe:replicated-region id="replicatedParent">
-        <gfe:lookup-region name="lookupChild">
+        <gfe:replicated-region name="replicatedChild">
             <gfe:partitioned-region name="partitionedGrandchild"/>
-        </gfe:lookup-region>
+        </gfe:replicated-region>
     </gfe:replicated-region>
-    
+
      <gfe:replicated-region id="parentWithSiblings">
         <gfe:replicated-region name="child1">
             <gfe:replicated-region name="grandChild11"/>
@@ -29,7 +29,7 @@
         </gfe:replicated-region>
         <gfe:replicated-region name="child2"/>
     </gfe:replicated-region>
-    
+
      <gfe:replicated-region id="complexNested">
        <gfe:cache-listener ref="c-listener"/>
         <gfe:replicated-region name="child1">
@@ -42,9 +42,9 @@
             <gfe:cache-writer ref="c-writer"/>
         </gfe:replicated-region>
     </gfe:replicated-region>
-    
+
     <bean id="c-listener" class="org.springframework.data.gemfire.SimpleCacheListener"/>
     <bean id="c-loader" class="org.springframework.data.gemfire.SimpleCacheLoader"/>
     <bean id="c-writer" class="org.springframework.data.gemfire.SimpleCacheWriter"/>
-    
+
 </beans>


### PR DESCRIPTION
This fixes the problem of subregions not initialized until the bean is referenced. AbstractRegionParser now, when it encounters a *-region child element, does a depth-first search for all nested regions and manages the hierarchy internally. Then for each subregion, calls parseCustomElement with no containingBeanDefinition. i.e., Spring sees it as a top level singleton bean. 
