### PR TITLE
Fixes JIRA issues SGF-230 and SGF-233 involving the persistence on a Asy...

### DIFF
--- a/src/main/java/org/springframework/data/gemfire/wan/AsyncEventQueueFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/wan/AsyncEventQueueFactoryBean.java
@@ -15,9 +15,6 @@
  */
 package org.springframework.data.gemfire.wan;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.springframework.util.Assert;
 
 import com.gemstone.gemfire.cache.Cache;
@@ -49,7 +46,7 @@ public class AsyncEventQueueFactoryBean extends AbstractWANComponentFactoryBean<
 	private Integer dispatcherThreads;
 	private Integer maximumQueueMemory;
 
-	private String diskStoreRef;
+	private String diskStoreReference;
 	private String orderPolicy;
 
 	/**
@@ -90,22 +87,6 @@ public class AsyncEventQueueFactoryBean extends AbstractWANComponentFactoryBean<
 		AsyncEventQueueFactory asyncEventQueueFactory = (this.factory != null ? (AsyncEventQueueFactory) factory
 			: cache.createAsyncEventQueueFactory());
 
-		if (diskStoreRef != null) {
-			persistent = (persistent == null || persistent);
-			Assert.isTrue(persistent, "Specifying a 'disk store' requires the persistent property to be true.");
-			asyncEventQueueFactory.setDiskStoreName(diskStoreRef);
-		}
-
-		if (diskSynchronous != null) {
-			persistent = (persistent == null || persistent);
-			Assert.isTrue(persistent, "Specifying 'disk synchronous' requires the persistent property to be true.");
-			asyncEventQueueFactory.setDiskSynchronous(diskSynchronous);
-		}
-
-		if (persistent != null) {
-			asyncEventQueueFactory.setPersistent(persistent);
-		}
-
 		if (batchSize != null) {
 			asyncEventQueueFactory.setBatchSize(batchSize);
 		}
@@ -123,6 +104,14 @@ public class AsyncEventQueueFactoryBean extends AbstractWANComponentFactoryBean<
 			asyncEventQueueFactory.setDispatcherThreads(dispatcherThreads);
 		}
 
+		if (diskStoreReference != null) {
+			asyncEventQueueFactory.setDiskStoreName(diskStoreReference);
+		}
+
+		if (diskSynchronous != null) {
+			asyncEventQueueFactory.setDiskSynchronous(diskSynchronous);
+		}
+
 		if (maximumQueueMemory != null) {
 			asyncEventQueueFactory.setMaximumQueueMemory(maximumQueueMemory);
 		}
@@ -136,6 +125,10 @@ public class AsyncEventQueueFactoryBean extends AbstractWANComponentFactoryBean<
 				"The value of Order Policy '$1%s' is invalid.", orderPolicy));
 
 			asyncEventQueueFactory.setOrderPolicy(Gateway.OrderPolicy.valueOf(orderPolicy.toUpperCase()));
+		}
+
+		if (persistent != null) {
+			asyncEventQueueFactory.setPersistent(persistent);
 		}
 
 		asyncEventQueue = asyncEventQueueFactory.create(getName(), this.asyncEventListener);
@@ -159,7 +152,7 @@ public class AsyncEventQueueFactoryBean extends AbstractWANComponentFactoryBean<
 	}
 
 	public void setDiskStoreRef(String diskStoreRef) {
-		this.diskStoreRef = diskStoreRef;
+		this.diskStoreReference = diskStoreRef;
 	}
 
 	public void setBatchSize(Integer batchSize) {

--- a/src/test/java/org/springframework/data/gemfire/wan/GatewaySenderFactoryBeanTest.java
+++ b/src/test/java/org/springframework/data/gemfire/wan/GatewaySenderFactoryBeanTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -82,6 +83,27 @@ public class GatewaySenderFactoryBeanTest {
 
 		if (dispatcherThreads != null) {
 			verify(mockGatewaySenderFactory).setDispatcherThreads(eq(dispatcherThreads));
+		}
+
+		String diskStoreReference = TestUtils.readField("diskStoreReference", factoryBean);
+
+		if (diskStoreReference != null) {
+			verify(mockGatewaySenderFactory).setDiskStoreName(eq(diskStoreReference));
+		}
+
+		Boolean diskSynchronous = TestUtils.readField("diskSynchronous", factoryBean);
+
+		if (diskSynchronous != null) {
+			verify(mockGatewaySenderFactory).setDiskSynchronous(eq(diskSynchronous));
+		}
+
+		Boolean persistent = TestUtils.readField("persistent", factoryBean);
+
+		if (persistent != null) {
+			verify(mockGatewaySenderFactory).setPersistenceEnabled(eq(persistent));
+		}
+		else {
+			verify(mockGatewaySenderFactory, never()).setPersistenceEnabled(true);
 		}
 	}
 
@@ -191,6 +213,49 @@ public class GatewaySenderFactoryBeanTest {
 		assertNotNull(gatewaySender);
 		assertEquals("g5", gatewaySender.getId());
 		assertEquals(42, gatewaySender.getRemoteDSId());
+	}
+
+	@Test
+	public void testGatewaySenderWithOverflowDiskStoreNoPersistence() throws Exception {
+		GatewaySenderFactory mockGatewaySenderFactory = createMockGatewaySenderFactory("g6", 51);
+
+		GatewaySenderFactoryBean factoryBean = new GatewaySenderFactoryBean(
+			createMockCacheWithGatewayInfrastructure(mockGatewaySenderFactory));
+
+		factoryBean.setName("g6");
+		factoryBean.setRemoteDistributedSystemId(51);
+		factoryBean.setPersistent(false);
+		factoryBean.setDiskStoreRef("queueOverflowDiskStore");
+		factoryBean.doInit();
+
+		verifyExpectations(factoryBean, mockGatewaySenderFactory);
+
+		GatewaySender gatewaySender = factoryBean.getObject();
+
+		assertNotNull(gatewaySender);
+		assertEquals("g6", gatewaySender.getId());
+		assertEquals(51, gatewaySender.getRemoteDSId());
+	}
+
+	@Test
+	public void testGatewaySenderWithDiskSynchronousSetPersistenceUnset() throws Exception {
+		GatewaySenderFactory mockGatewaySenderFactory = createMockGatewaySenderFactory("g7", 51);
+
+		GatewaySenderFactoryBean factoryBean = new GatewaySenderFactoryBean(
+			createMockCacheWithGatewayInfrastructure(mockGatewaySenderFactory));
+
+		factoryBean.setName("g7");
+		factoryBean.setRemoteDistributedSystemId(51);
+		factoryBean.setDiskSynchronous(true);
+		factoryBean.doInit();
+
+		verifyExpectations(factoryBean, mockGatewaySenderFactory);
+
+		GatewaySender gatewaySender = factoryBean.getObject();
+
+		assertNotNull(gatewaySender);
+		assertEquals("g7", gatewaySender.getId());
+		assertEquals(51, gatewaySender.getRemoteDSId());
 	}
 
 }


### PR DESCRIPTION
...nc Event Queue or Gateway Sender when a logical Disk Store name has been specified, or the disk-synchronous attribute has been set, requiring persistence to be enabled when all the user wanted was overflow.
