### PR TITLE
Remove redundant aspectjrt dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ dependencies {
     compile "org.springframework:spring-tx:$springVersion"
 	compile "org.springframework:spring-aop:$springVersion"
 	compile 'org.aspectj:aspectjweaver:1.7.2'
-	compile 'org.aspectj:aspectjrt:1.7.2'
 	compile 'org.codehaus.jackson:jackson-core-asl:1.9.12'
 	compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.12'
 


### PR DESCRIPTION
aspectjweaver is a superset of aspectjrt, making the dependency on aspectjrt redundant
