### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,7 @@ test {
 // Common dependencies
 dependencies {
     // Logging
-    compile 'org.aspectj:aspectjrt:1.7.2'
-    compile 'org.aspectj:aspectjweaver:1.7.2'
+    compile 'org.aspectj:aspectjweaver:1.7.4'
     compile 'org.codehaus.jackson:jackson-core-asl:1.9.12'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.12'
     compile "org.slf4j:slf4j-api:$slf4jVersion"
@@ -71,24 +70,23 @@ dependencies {
     testCompile("org.springframework:spring-test:$springVersion") {
       exclude group: "commons-logging", module: "commons-logging"
     }
-    testCompile "junit:junit-dep:$junitVersion"
+    testCompile "junit:junit:$junitVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile "org.hamcrest:hamcrest-core:$hamcrestVersion"
     testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
-    testCompile "cglib:cglib:${cglibVersion}"
 
     testCompile "javax.annotation:jsr250-api:1.0", optional
 	  testCompile "org.apache.derby:derbyLocale_zh_TW:10.9.1.0"
 }
 
 sourceCompatibility = 1.6
-targetCompatibility = 1.6 
+targetCompatibility = 1.6
 
 javadoc {
   ext.srcDir = file("${projectDir}/docs/src/api")
   destinationDir = file("${buildDir}/api")
   ext.tmpDir = file("${buildDir}/api-work")
-  
+
   configure(options) {
       stylesheetFile = file("${srcDir}/spring-javadoc.css")
       overview = "${srcDir}/overview.html"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,11 @@
-slf4jVersion=1.6.4
-junitVersion=4.8.2
+slf4jVersion=1.7.6
+junitVersion=4.11
 gemfireVersion=7.0.1
 spring.range="[3.2.0, 4.0.0)"
 springVersion=3.2.8.RELEASE
 springDataCommonsVersion=1.8.0.BUILD-SNAPSHOT
-log4jVersion=1.2.16
-hamcrestVersion=1.2.1
+log4jVersion=1.2.17
+hamcrestVersion=1.3
 version=1.4.0.BUILD-SNAPSHOT
 gemfire.range="[6.5, 8.0)"
-cglibVersion=2.2
-mockitoVersion=1.9.0
+mockitoVersion=1.9.5


### PR DESCRIPTION
Various dependencies have been updated to their latest versions. The dependency on aspectjrt has been removed: it's unnecessary to depend on both rt and weaver as aspectjweaver contains a superset of
aspectjrt. The dependency on cglib has been removed as it was not being used.
