### PR TITLE
Implements JIRA improvement SGF-281 involving the addition of logic in S...

### DIFF
--- a/src/main/java/org/springframework/data/gemfire/LocalRegionFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/LocalRegionFactoryBean.java
@@ -44,16 +44,23 @@ public class LocalRegionFactoryBean<K, V> extends RegionFactoryBean<K, V> {
 		if (dataPolicy == null || DataPolicy.NORMAL.equals(dataPolicy)) {
 			// NOTE this is safe since a LOCAL Scoped NORMAL Region requiring persistence can be satisfied with
 			// PERSISTENT_REPLICATE, per the RegionShortcut.LOCAL_PERSISTENT
-			regionFactory.setDataPolicy(isPersistent() ? DataPolicy.PERSISTENT_REPLICATE : DataPolicy.NORMAL);
+			DataPolicy resolvedDataPolicy = (isPersistent() ? DataPolicy.PERSISTENT_REPLICATE : DataPolicy.NORMAL);
+
+			regionFactory.setDataPolicy(resolvedDataPolicy);
+			setDataPolicy(resolvedDataPolicy);
 		}
 		else if (DataPolicy.PRELOADED.equals(dataPolicy)) {
 			// NOTE this is safe since a LOCAL Scoped PRELOADED Region requiring persistence can be satisfied with
 			// PERSISTENT_REPLICATE, per the RegionShortcut.LOCAL_PERSISTENT
-			regionFactory.setDataPolicy(isPersistent() ? DataPolicy.PERSISTENT_REPLICATE : DataPolicy.PRELOADED);
+			DataPolicy resolvedDataPolicy = (isPersistent() ? DataPolicy.PERSISTENT_REPLICATE : DataPolicy.PRELOADED);
+
+			regionFactory.setDataPolicy(resolvedDataPolicy);
+			setDataPolicy(resolvedDataPolicy);
 		}
 		else if (DataPolicy.PERSISTENT_REPLICATE.equals(dataPolicy)
 				&& RegionShortcutWrapper.valueOf(getShortcut()).isPersistent()) {
 			regionFactory.setDataPolicy(dataPolicy);
+			setDataPolicy(dataPolicy);
 		}
 		else {
 			throw new IllegalArgumentException(String.format("Data Policy '%1$s' is not supported for Local Regions.",

--- a/src/main/java/org/springframework/data/gemfire/PartitionedRegionFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/PartitionedRegionFactoryBean.java
@@ -48,6 +48,7 @@ public class PartitionedRegionFactoryBean<K, V> extends RegionFactoryBean<K, V> 
 		assertDataPolicyAndPersistentAttributesAreCompatible(dataPolicy);
 
 		regionFactory.setDataPolicy(dataPolicy);
+		setDataPolicy(dataPolicy);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/gemfire/ReplicatedRegionFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/ReplicatedRegionFactoryBean.java
@@ -45,6 +45,7 @@ public class ReplicatedRegionFactoryBean<K, V> extends RegionFactoryBean<K, V> {
 		assertDataPolicyAndPersistentAttributesAreCompatible(dataPolicy);
 
 		regionFactory.setDataPolicy(dataPolicy);
+		setDataPolicy(dataPolicy);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/gemfire/config/LocalRegionNamespaceTest.java
+++ b/src/test/java/org/springframework/data/gemfire/config/LocalRegionNamespaceTest.java
@@ -36,6 +36,7 @@ import org.springframework.util.ObjectUtils;
 
 import com.gemstone.gemfire.cache.Cache;
 import com.gemstone.gemfire.cache.CacheListener;
+import com.gemstone.gemfire.cache.DataPolicy;
 import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.RegionAttributes;
 import com.gemstone.gemfire.cache.Scope;
@@ -63,7 +64,7 @@ public class LocalRegionNamespaceTest {
 	public void testPublishingLocal() throws Exception {
 		assertTrue(context.containsBean("pub"));
 		RegionFactoryBean fb = context.getBean("&pub", RegionFactoryBean.class);
-		assertNull(TestUtils.readField("dataPolicy", fb));
+		assertEquals(DataPolicy.NORMAL, TestUtils.readField("dataPolicy", fb));
 		assertEquals(Scope.LOCAL, TestUtils.readField("scope", fb));
 		assertEquals("publisher", TestUtils.readField("name", fb));
 		RegionAttributes attrs = TestUtils.readField("attributes", fb);

--- a/src/test/java/org/springframework/data/gemfire/config/RegionsWithDiskStoreAndPersistenceEvictionSettingsTest.java
+++ b/src/test/java/org/springframework/data/gemfire/config/RegionsWithDiskStoreAndPersistenceEvictionSettingsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2010-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.gemfire.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.data.gemfire.test.GemfireTestApplicationContextInitializer;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.gemstone.gemfire.cache.DataPolicy;
+import com.gemstone.gemfire.cache.EvictionAction;
+import com.gemstone.gemfire.cache.Region;
+
+/**
+ * The RegionsWithDiskStoreAndPersistenceEvictionSettingsTest class is a test suite testing the functionality
+ * of GemFire Cache Regions when persistent/non-persistent with and without Eviction settings when specifying a
+ * Disk Store.
+ *
+ * @author John Blum
+ * @see org.junit.Test
+ * @see org.springframework.test.context.ContextConfiguration
+ * @since 1.4.0.RC1
+ */
+@ContextConfiguration(initializers = GemfireTestApplicationContextInitializer.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class RegionsWithDiskStoreAndPersistenceEvictionSettingsTest {
+
+	@Resource(name = "NotPersistentNoOverflowRegion")
+	private Region notPersistentNoOverflowRegion;
+
+	@Resource(name = "NotPersistentOverflowRegion")
+	private Region notPersistentOverflowRegion;
+
+	@Resource(name = "PersistentNoOverflowRegion")
+	private Region persistentNoOverflowRegion;
+
+	@Resource(name = "PersistentOverflowRegion")
+	private Region persistentOverflowRegion;
+
+	@Test
+	public void testNotPersistentNoOverflowRegion() {
+		assertNotNull("The Not Persistent, No Overflow Region was not properly configured and initialized!", 
+			notPersistentNoOverflowRegion);
+
+		assertNotNull(notPersistentNoOverflowRegion.getAttributes());
+		assertEquals(DataPolicy.PARTITION, notPersistentNoOverflowRegion.getAttributes().getDataPolicy());
+		assertNotNull(notPersistentNoOverflowRegion.getAttributes().getEvictionAttributes());
+		assertEquals(EvictionAction.NONE, notPersistentNoOverflowRegion.getAttributes()
+			.getEvictionAttributes().getAction());
+		assertNull(notPersistentNoOverflowRegion.getAttributes().getDiskStoreName());
+	}
+
+	@Test
+	public void testNotPersistentOverflowRegion() {
+		assertNotNull("The Not Persistent, Overflow Region was not properly configured and initialized!",
+			notPersistentOverflowRegion);
+
+		assertNotNull(notPersistentOverflowRegion.getAttributes());
+		assertEquals(DataPolicy.PARTITION, notPersistentOverflowRegion.getAttributes().getDataPolicy());
+		assertNotNull(notPersistentOverflowRegion.getAttributes().getEvictionAttributes());
+		assertEquals(EvictionAction.OVERFLOW_TO_DISK, notPersistentOverflowRegion.getAttributes()
+			.getEvictionAttributes().getAction());
+		assertEquals("DiskStoreOne", notPersistentOverflowRegion.getAttributes().getDiskStoreName());
+	}
+
+	@Test
+	public void testPersistentNoOverflowRegion() {
+		assertNotNull("The Persistent, No Overflow Region was not properly configured and initialized!",
+			persistentNoOverflowRegion);
+
+		assertNotNull(persistentNoOverflowRegion.getAttributes());
+		assertEquals(DataPolicy.PERSISTENT_PARTITION, persistentNoOverflowRegion.getAttributes().getDataPolicy());
+		assertNotNull(persistentNoOverflowRegion.getAttributes().getEvictionAttributes());
+		assertEquals(EvictionAction.LOCAL_DESTROY, persistentNoOverflowRegion.getAttributes()
+			.getEvictionAttributes().getAction());
+		assertEquals("DiskStoreOne", persistentNoOverflowRegion.getAttributes().getDiskStoreName());
+	}
+
+	@Test
+	public void testPersistentOverflowRegion() {
+		assertNotNull("The Persistent, Overflow Region was not properly configured and initialized!",
+			persistentOverflowRegion);
+
+		assertNotNull(persistentOverflowRegion.getAttributes());
+		assertEquals(DataPolicy.PERSISTENT_PARTITION, persistentOverflowRegion.getAttributes().getDataPolicy());
+		assertNotNull(persistentOverflowRegion.getAttributes().getEvictionAttributes());
+		assertEquals(EvictionAction.OVERFLOW_TO_DISK, persistentOverflowRegion.getAttributes()
+			.getEvictionAttributes().getAction());
+		assertEquals("DiskStoreOne", persistentOverflowRegion.getAttributes().getDiskStoreName());
+	}
+
+}

--- a/src/test/java/org/springframework/data/gemfire/test/MockRegionFactory.java
+++ b/src/test/java/org/springframework/data/gemfire/test/MockRegionFactory.java
@@ -14,6 +14,7 @@ package org.springframework.data.gemfire.test;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyFloat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -48,10 +49,12 @@ import com.gemstone.gemfire.cache.query.QueryService;
 @SuppressWarnings("deprecation")
 public class MockRegionFactory<K,V>   {
 
-	private static QueryService queryService =  mock(QueryService.class);
+	private static QueryService queryService = mock(QueryService.class);
 	private static RegionService regionService = mock(RegionService.class);
 
 	private com.gemstone.gemfire.cache.AttributesFactory<K,V> attributesFactory;
+
+  	private RegionAttributes regionAttributes;
 
 	private final StubCache cache;
 
@@ -68,7 +71,8 @@ public class MockRegionFactory<K,V>   {
 		attributesFactory = (attributes != null ? new com.gemstone.gemfire.cache.AttributesFactory<K,V>(attributes)
 			: new com.gemstone.gemfire.cache.AttributesFactory<K,V>());
 
-		//Workaround for GemFire bug
+		// Workaround for GemFire bug
+		// TODO ?!?!?!
 		if (attributes !=null) {
 			attributesFactory.setLockGrantor(attributes.isLockGrantor());
 		}
@@ -76,18 +80,18 @@ public class MockRegionFactory<K,V>   {
 		final RegionFactory<K, V> regionFactory = mock(RegionFactory.class);
 
 		when(regionFactory.create(anyString())).thenAnswer(new Answer<Region>() {
-			@Override
-			public Region answer(InvocationOnMock invocation) throws Throwable {
+			@Override public Region answer(InvocationOnMock invocation) throws Throwable {
 				String name = (String) invocation.getArguments()[0];
 				Region region = mockRegion(name);
+
 				cache.allRegions().put(name, region);
+
 				return region;
 			}
 		});
 
-		when(regionFactory.createSubregion(any(Region.class),anyString())).thenAnswer(new Answer<Region>() {
-			@Override
-			public Region answer(InvocationOnMock invocation) throws Throwable {
+		when(regionFactory.createSubregion(any(Region.class), anyString())).thenAnswer(new Answer<Region>() {
+			@Override public Region answer(InvocationOnMock invocation) throws Throwable {
 				Region parent = (Region) invocation.getArguments()[0];
 				String name = (String) invocation.getArguments()[1];
 				String parentRegionName = null;
@@ -112,380 +116,327 @@ public class MockRegionFactory<K,V>   {
 		});
 
 		when(regionFactory.setCacheLoader(any(CacheLoader.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				CacheLoader val =  (CacheLoader)invocation.getArguments()[0];
-				attributesFactory.setCacheLoader(val);
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				CacheLoader cacheLoader = (CacheLoader) invocation.getArguments()[0];
+				attributesFactory.setCacheLoader(cacheLoader);
 				return regionFactory;
 			}
 		});
 
 		when(regionFactory.setCacheWriter(any(CacheWriter.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				CacheWriter val =  (CacheWriter)invocation.getArguments()[0];
-				attributesFactory.setCacheWriter(val);
-				return regionFactory;
-			}
-		});
-
-
-		when(regionFactory.addAsyncEventQueueId(anyString())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				String val =  (String)invocation.getArguments()[0];
-				attributesFactory.addAsyncEventQueueId(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.addCacheListener(any(CacheListener.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				CacheListener val =  (CacheListener)invocation.getArguments()[0];
-				attributesFactory.addCacheListener(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setEvictionAttributes(any(EvictionAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				EvictionAttributes val =  (EvictionAttributes)invocation.getArguments()[0];
-				attributesFactory.setEvictionAttributes(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setEntryIdleTimeout(any(ExpirationAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				ExpirationAttributes val =  (ExpirationAttributes)invocation.getArguments()[0];
-				attributesFactory.setEntryIdleTimeout(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setCustomEntryIdleTimeout(any(CustomExpiry.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				CustomExpiry val =  (CustomExpiry)invocation.getArguments()[0];
-				attributesFactory.setCustomEntryIdleTimeout(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setEntryTimeToLive(any(ExpirationAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				ExpirationAttributes val =  (ExpirationAttributes)invocation.getArguments()[0];
-				attributesFactory.setEntryTimeToLive(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setCustomEntryTimeToLive(any(CustomExpiry.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				CustomExpiry val =  (CustomExpiry)invocation.getArguments()[0];
-				attributesFactory.setCustomEntryTimeToLive(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setRegionIdleTimeout(any(ExpirationAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				ExpirationAttributes val =  (ExpirationAttributes)invocation.getArguments()[0];
-				attributesFactory.setRegionIdleTimeout(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setRegionTimeToLive(any(ExpirationAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				ExpirationAttributes val =  (ExpirationAttributes)invocation.getArguments()[0];
-				attributesFactory.setRegionTimeToLive(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setScope(any(Scope.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				Scope val =  (Scope)invocation.getArguments()[0];
-				attributesFactory.setScope(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setDataPolicy(any(DataPolicy.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				DataPolicy val =  (DataPolicy)invocation.getArguments()[0];
-				attributesFactory.setDataPolicy(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setEarlyAck(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setEarlyAck(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setMulticastEnabled(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setMulticastEnabled(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setPoolName(anyString())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				String val =  (String)invocation.getArguments()[0];
-				attributesFactory.setPoolName(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setEnableGateway(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setEnableGateway(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setEnableAsyncConflation(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setEnableAsyncConflation(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setEnableSubscriptionConflation(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setEnableSubscriptionConflation(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setKeyConstraint(any(Class.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				Class val =  (Class)invocation.getArguments()[0];
-				attributesFactory.setKeyConstraint(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setValueConstraint(any(Class.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				Class val =  (Class)invocation.getArguments()[0];
-				attributesFactory.setValueConstraint(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setInitialCapacity(anyInt())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				int val =  (Integer)invocation.getArguments()[0];
-				System.out.println("setInitialCapacity " + val);
-				attributesFactory.setInitialCapacity(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setLoadFactor(anyInt())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				int val =  (Integer)invocation.getArguments()[0];
-				attributesFactory.setLoadFactor(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setConcurrencyLevel(anyInt())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				int val =  (Integer)invocation.getArguments()[0];
-				attributesFactory.setConcurrencyLevel(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setConcurrencyChecksEnabled(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setConcurrencyChecksEnabled(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setDiskWriteAttributes(any(com.gemstone.gemfire.cache.DiskWriteAttributes.class)))
-				.thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				com.gemstone.gemfire.cache.DiskWriteAttributes val =
-					(com.gemstone.gemfire.cache.DiskWriteAttributes) invocation.getArguments()[0];
-				attributesFactory.setDiskWriteAttributes(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setDiskStoreName(anyString())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				String val =  (String)invocation.getArguments()[0];
-				attributesFactory.setDiskStoreName(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setDiskSynchronous(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setDiskSynchronous(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setDiskDirs(any(File[].class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				File[] val =  (File[])invocation.getArguments()[0];
-				attributesFactory.setDiskDirs(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setDiskDirsAndSizes(any(File[].class),any(int[].class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				File[] val0 =  (File[])invocation.getArguments()[0];
-				int[] val1 = (int[])invocation.getArguments()[1];
-				attributesFactory.setDiskDirsAndSizes(val0,val1);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setPartitionAttributes(any(PartitionAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				PartitionAttributes val =  (PartitionAttributes)invocation.getArguments()[0];
-				attributesFactory.setPartitionAttributes(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setMembershipAttributes(any(MembershipAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				MembershipAttributes val =  (MembershipAttributes)invocation.getArguments()[0];
-				attributesFactory.setMembershipAttributes(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setIndexMaintenanceSynchronous(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setIndexMaintenanceSynchronous(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setStatisticsEnabled(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setStatisticsEnabled(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setIgnoreJTA(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setIgnoreJTA(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setLockGrantor(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				System.out.println("setting lock grantor to " + val);
-				attributesFactory.setLockGrantor(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setSubscriptionAttributes(any(SubscriptionAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				SubscriptionAttributes val =  (SubscriptionAttributes)invocation.getArguments()[0];
-				attributesFactory.setSubscriptionAttributes(val);
-				return regionFactory;
-			}
-		});
-
-		when(regionFactory.setGatewayHubId(anyString())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				String val =  (String)invocation.getArguments()[0];
-				attributesFactory.setGatewayHubId(val);
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				CacheWriter cacheWriter = (CacheWriter) invocation.getArguments()[0];
+				attributesFactory.setCacheWriter(cacheWriter);
 				return regionFactory;
 			}
 		});
 
 		when(regionFactory.setCloningEnabled(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				boolean val =  (Boolean)invocation.getArguments()[0];
-				attributesFactory.setCloningEnabled(val);
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean cloningEnabled = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setCloningEnabled(cloningEnabled);
 				return regionFactory;
 			}
 		});
 
-		when(regionFactory.addGatewaySenderId(anyString())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				String val =  (String)invocation.getArguments()[0];
-				attributesFactory.addGatewaySenderId(val);
+		when(regionFactory.setConcurrencyChecksEnabled(anyBoolean())).thenAnswer(new Answer<RegionFactory>() {
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean concurrencyChecksEnabled = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setConcurrencyChecksEnabled(concurrencyChecksEnabled);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setConcurrencyLevel(anyInt())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				int concurrencyLevel = (Integer) invocation.getArguments()[0];
+				attributesFactory.setConcurrencyLevel(concurrencyLevel);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setDataPolicy(any(DataPolicy.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				DataPolicy dataPolicy = (DataPolicy) invocation.getArguments()[0];
+				attributesFactory.setDataPolicy(dataPolicy);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setDiskDirs(any(File[].class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				File[] diskDirectories = (File[]) invocation.getArguments()[0];
+				attributesFactory.setDiskDirs(diskDirectories);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setDiskDirsAndSizes(any(File[].class), any(int[].class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				File[] diskDirectories = (File[]) invocation.getArguments()[0];
+				int[] diskSizes = (int[]) invocation.getArguments()[1];
+				attributesFactory.setDiskDirsAndSizes(diskDirectories, diskSizes);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setDiskStoreName(anyString())).thenAnswer(new Answer<RegionFactory>() {
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				String diskStoreName = (String) invocation.getArguments()[0];
+				attributesFactory.setDiskStoreName(diskStoreName);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setDiskWriteAttributes(any(com.gemstone.gemfire.cache.DiskWriteAttributes.class)))
+			.thenAnswer(new Answer<RegionFactory>() {
+				@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+					com.gemstone.gemfire.cache.DiskWriteAttributes diskWriteAttributes =
+						(com.gemstone.gemfire.cache.DiskWriteAttributes) invocation.getArguments()[0];
+					attributesFactory.setDiskWriteAttributes(diskWriteAttributes);
+					return regionFactory;
+				}
+			});
+
+		when(regionFactory.setDiskSynchronous(anyBoolean())).thenAnswer(new Answer<RegionFactory>() {
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean diskSynchronous = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setDiskSynchronous(diskSynchronous);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setEarlyAck(anyBoolean())).thenAnswer(new Answer<RegionFactory>() {
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean earlyAck = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setEarlyAck(earlyAck);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setEnableAsyncConflation(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean enableAsyncConflation = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setEnableAsyncConflation(enableAsyncConflation);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setEnableGateway(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean enableGateway = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setEnableGateway(enableGateway);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setEnableSubscriptionConflation(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean enableSubscriptionConflation = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setEnableSubscriptionConflation(enableSubscriptionConflation);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setEntryIdleTimeout(any(ExpirationAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				ExpirationAttributes entryIdleTimeout = (ExpirationAttributes) invocation.getArguments()[0];
+				attributesFactory.setEntryIdleTimeout(entryIdleTimeout);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setCustomEntryIdleTimeout(any(CustomExpiry.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				CustomExpiry customEntryIdleTimeout = (CustomExpiry) invocation.getArguments()[0];
+				attributesFactory.setCustomEntryIdleTimeout(customEntryIdleTimeout);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setEntryTimeToLive(any(ExpirationAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				ExpirationAttributes entryTimeToLive = (ExpirationAttributes) invocation.getArguments()[0];
+				attributesFactory.setEntryTimeToLive(entryTimeToLive);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setCustomEntryTimeToLive(any(CustomExpiry.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				CustomExpiry customEntryTimeToLive = (CustomExpiry) invocation.getArguments()[0];
+				attributesFactory.setCustomEntryTimeToLive(customEntryTimeToLive);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setEvictionAttributes(any(EvictionAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				EvictionAttributes evictionAttributes = (EvictionAttributes) invocation.getArguments()[0];
+				attributesFactory.setEvictionAttributes(evictionAttributes);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setGatewayHubId(anyString())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				String gatewayHubId = (String) invocation.getArguments()[0];
+				attributesFactory.setGatewayHubId(gatewayHubId);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setIgnoreJTA(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean ignoreJta = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setIgnoreJTA(ignoreJta);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setIndexMaintenanceSynchronous(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean indexMaintenanceSynchronous = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setIndexMaintenanceSynchronous(indexMaintenanceSynchronous);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setInitialCapacity(anyInt())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				int initialCapacity = (Integer) invocation.getArguments()[0];
+				attributesFactory.setInitialCapacity(initialCapacity);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setKeyConstraint(any(Class.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				Class keyConstraint = (Class) invocation.getArguments()[0];
+				attributesFactory.setKeyConstraint(keyConstraint);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setLoadFactor(anyFloat())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				float loadFactor = (Float) invocation.getArguments()[0];
+				attributesFactory.setLoadFactor(loadFactor);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setLockGrantor(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean lockGrantor = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setLockGrantor(lockGrantor);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setMembershipAttributes(any(MembershipAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				MembershipAttributes membershipAttributes = (MembershipAttributes) invocation.getArguments()[0];
+				attributesFactory.setMembershipAttributes(membershipAttributes);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setMulticastEnabled(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean multicastEnabled = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setMulticastEnabled(multicastEnabled);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setPartitionAttributes(any(PartitionAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				PartitionAttributes partitionAttributes = (PartitionAttributes) invocation.getArguments()[0];
+				attributesFactory.setPartitionAttributes(partitionAttributes);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setPoolName(anyString())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				String poolName = (String) invocation.getArguments()[0];
+				attributesFactory.setPoolName(poolName);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setRegionIdleTimeout(any(ExpirationAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				ExpirationAttributes regionIdleTimeout = (ExpirationAttributes) invocation.getArguments()[0];
+				attributesFactory.setRegionIdleTimeout(regionIdleTimeout);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setRegionTimeToLive(any(ExpirationAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				ExpirationAttributes regionTimeToLive = (ExpirationAttributes) invocation.getArguments()[0];
+				attributesFactory.setRegionTimeToLive(regionTimeToLive);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setScope(any(Scope.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				Scope scope = (Scope) invocation.getArguments()[0];
+				attributesFactory.setScope(scope);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setStatisticsEnabled(anyBoolean())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				boolean statisticsEnabled = (Boolean) invocation.getArguments()[0];
+				attributesFactory.setStatisticsEnabled(statisticsEnabled);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setSubscriptionAttributes(any(SubscriptionAttributes.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				SubscriptionAttributes subscriptionAttributes = (SubscriptionAttributes) invocation.getArguments()[0];
+				attributesFactory.setSubscriptionAttributes(subscriptionAttributes);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.setValueConstraint(any(Class.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				Class valueConstraint = (Class) invocation.getArguments()[0];
+				attributesFactory.setValueConstraint(valueConstraint);
 				return regionFactory;
 			}
 		});
 
 		when(regionFactory.addAsyncEventQueueId(anyString())).thenAnswer(new Answer<RegionFactory>(){
-			@Override
-			public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
-				String val =  (String)invocation.getArguments()[0];
-				attributesFactory.addAsyncEventQueueId(val);
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				String asyncEventQueueId = (String) invocation.getArguments()[0];
+				attributesFactory.addAsyncEventQueueId(asyncEventQueueId);
 				return regionFactory;
 			}
 		});
 
+		when(regionFactory.addCacheListener(any(CacheListener.class))).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				CacheListener cacheListener = (CacheListener) invocation.getArguments()[0];
+				attributesFactory.addCacheListener(cacheListener);
+				return regionFactory;
+			}
+		});
+
+		when(regionFactory.addGatewaySenderId(anyString())).thenAnswer(new Answer<RegionFactory>(){
+			@Override public RegionFactory answer(InvocationOnMock invocation) throws Throwable {
+				String gatewaySenderId = (String) invocation.getArguments()[0];
+				attributesFactory.addGatewaySenderId(gatewaySenderId);
+				return regionFactory;
+			}
+		});
 
 		return regionFactory;
 	}
@@ -495,24 +446,24 @@ public class MockRegionFactory<K,V>   {
 		return createMockRegionFactory();
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public Region mockRegion(String name) {
-		RegionService regionService = mockRegionService();
+		regionAttributes = attributesFactory.create();
+
+		RegionService mockRegionService = mockRegionService();
 		Region region = mock(Region.class);
 
-		when(region.getRegionService()).thenReturn(regionService);
-
 		when(region.getAttributes()).thenAnswer(new Answer<RegionAttributes>() {
-			@Override
-			public RegionAttributes answer(InvocationOnMock invocation) throws Throwable {
-				return attributesFactory.create();
+			@Override public RegionAttributes answer(InvocationOnMock invocation) throws Throwable {
+				return regionAttributes;
 			}
 		});
 
 		when(region.getFullPath()).thenReturn(name);
 		when(region.getName()).thenReturn(name);
+    	when(region.getRegionService()).thenReturn(mockRegionService);
 
-		when(region.getSubregion(anyString())).thenAnswer(new Answer<Region>() {
+    	when(region.getSubregion(anyString())).thenAnswer(new Answer<Region>() {
 			@Override
 			public Region answer(InvocationOnMock invocation) throws Throwable {
 				Region parent = (Region) invocation.getMock();
@@ -549,7 +500,7 @@ public class MockRegionFactory<K,V>   {
 	}
 
 	public static RegionService mockRegionService() {
-		when(regionService.getQueryService()).thenReturn(queryService);
+		when(regionService.getQueryService()).thenReturn(mockQueryService());
 		return regionService;
 	}
 

--- a/src/test/java/org/springframework/data/gemfire/test/StubCache.java
+++ b/src/test/java/org/springframework/data/gemfire/test/StubCache.java
@@ -63,6 +63,8 @@ import com.gemstone.gemfire.pdx.PdxSerializer;
 @SuppressWarnings("deprecation")
 public class StubCache implements Cache {
 
+	protected static final String NOT_IMPLEMENTED = "Not Implemented!";
+
 	private Properties properties;
 	
 	private DistributedSystem distributedSystem;
@@ -289,8 +291,7 @@ public class StubCache implements Cache {
 	 * @see com.gemstone.gemfire.cache.GemFireCache#loadCacheXml(java.io.InputStream)
 	 */
 	@Override
-	public void loadCacheXml(InputStream is) throws TimeoutException, CacheWriterException, GatewayException,
-			RegionExistsException {
+	public void loadCacheXml(InputStream is) throws TimeoutException, CacheWriterException, GatewayException, RegionExistsException {
 	}
 
 	/* (non-Javadoc)
@@ -323,7 +324,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public PdxInstance createPdxEnum(String arg0, String arg1, int arg2) {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -331,7 +332,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public PdxInstanceFactory createPdxInstanceFactory(String arg0) {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -339,7 +340,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public CancelCriterion getCancelCriterion() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -394,7 +395,7 @@ public class StubCache implements Cache {
 	@Override
 	@Deprecated
 	public com.gemstone.gemfire.cache.util.BridgeServer addBridgeServer() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -453,36 +454,16 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	@Deprecated
-	public <K, V> Region<K, V> createRegion(String arg0, RegionAttributes<K, V> arg1) throws RegionExistsException,
-			TimeoutException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException();
+	public <K, V> Region<K, V> createRegion(String arg0, RegionAttributes<K, V> arg1) throws RegionExistsException, TimeoutException {
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
 	 * @see com.gemstone.gemfire.cache.Cache#createRegionFactory()
 	 */
-	@SuppressWarnings("unchecked")
 	@Override
+	@SuppressWarnings("unchecked")
 	public <K, V> RegionFactory<K, V> createRegionFactory() {
-		return new MockRegionFactory<K,V>(this).createRegionFactory();
-	}
-
-	/* (non-Javadoc)
-	 * @see com.gemstone.gemfire.cache.Cache#createRegionFactory(com.gemstone.gemfire.cache.RegionShortcut)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public <K, V> RegionFactory<K, V> createRegionFactory(RegionShortcut shortCut) {
-		return new MockRegionFactory<K,V>(this).createRegionFactory();
-	}
-
-	/* (non-Javadoc)
-	 * @see com.gemstone.gemfire.cache.Cache#createRegionFactory(java.lang.String)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public <K, V> RegionFactory<K, V> createRegionFactory(String arg0) {
 		return new MockRegionFactory<K,V>(this).createRegionFactory();
 	}
 
@@ -495,14 +476,30 @@ public class StubCache implements Cache {
 	}
 
 	/* (non-Javadoc)
+	 * @see com.gemstone.gemfire.cache.Cache#createRegionFactory(com.gemstone.gemfire.cache.RegionShortcut)
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K, V> RegionFactory<K, V> createRegionFactory(RegionShortcut shortcut) {
+		return new MockRegionFactory<K,V>(this).createRegionFactory();
+	}
+
+	/* (non-Javadoc)
+	 * @see com.gemstone.gemfire.cache.Cache#createRegionFactory(java.lang.String)
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K, V> RegionFactory<K, V> createRegionFactory(String regionAttributesId) {
+		return new MockRegionFactory<K,V>(this).createRegionFactory();
+	}
+
+	/* (non-Javadoc)
 	 * @see com.gemstone.gemfire.cache.Cache#createVMRegion(java.lang.String, com.gemstone.gemfire.cache.RegionAttributes)
 	 */
 	@Override
 	@Deprecated
-	public <K, V> Region<K, V> createVMRegion(String arg0, RegionAttributes<K, V> arg1) throws RegionExistsException,
-			TimeoutException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException();
+	public <K, V> Region<K, V> createVMRegion(String arg0, RegionAttributes<K, V> arg1) throws RegionExistsException, TimeoutException {
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -510,7 +507,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public Set<DistributedMember> getAdminMembers() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -518,7 +515,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public AsyncEventQueue getAsyncEventQueue(String name) {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -526,7 +523,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public Set<AsyncEventQueue> getAsyncEventQueues() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -535,7 +532,7 @@ public class StubCache implements Cache {
 	@Override
 	@Deprecated
 	public List<CacheServer> getBridgeServers() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -543,7 +540,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public List<CacheServer> getCacheServers() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -592,7 +589,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public GatewaySender getGatewaySender(String name) {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -625,7 +622,7 @@ public class StubCache implements Cache {
 	@Override
 	@Deprecated
 	public LogWriterI18n getLoggerI18n() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -633,7 +630,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public Set<DistributedMember> getMembers() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -642,7 +639,7 @@ public class StubCache implements Cache {
 	@SuppressWarnings({"rawtypes"})
 	@Override
 	public Set<DistributedMember> getMembers(Region arg0) {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -667,7 +664,7 @@ public class StubCache implements Cache {
 	@Override
 	@Deprecated
 	public LogWriterI18n getSecurityLoggerI18n() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -675,7 +672,7 @@ public class StubCache implements Cache {
 	 */
 	@Override
 	public CacheSnapshotService getSnapshotService() {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -692,7 +689,6 @@ public class StubCache implements Cache {
 	@Override
 	@Deprecated
 	public void readyForEvents() {
-		// TODO Auto-generated method stub	
 	}
 
 	/* (non-Javadoc)
@@ -709,7 +705,7 @@ public class StubCache implements Cache {
 	@Override
 	@Deprecated
 	public GatewayHub setGatewayHub(String arg0, int arg1) {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	/* (non-Javadoc)
@@ -752,7 +748,7 @@ public class StubCache implements Cache {
 	public void setSearchTimeout(int arg0) {
 		this.searchTimeout = arg0;
 	}
-	
+
 	DistributedSystem mockDistributedSystem() {
 		DistributedSystem ds = mock(DistributedSystem.class);
 		DistributedMember dm = mockDistributedMember();
@@ -765,18 +761,18 @@ public class StubCache implements Cache {
 		when(ds.getDistributedMember()).thenReturn(dm);
 		return ds;
 	}
-	
+
 	DistributedMember mockDistributedMember() {
 		DistributedMember dm = mock(DistributedMember.class);
 		when(dm.getHost()).thenReturn("mockDistributedMember.host");
 		when(dm.getName()).thenReturn("mockDistributedMember");
 		return dm;
 	}
-	
+
 	CacheServer mockCacheServer() {
 		return new StubCacheServer();
 	}
-	
+
 	GatewayHub mockGatewayHub() {
 		final Gateway gw = mock(Gateway.class);
 		final GatewayQueueAttributes queueAttributes= mock(GatewayQueueAttributes.class);
@@ -793,7 +789,7 @@ public class StubCache implements Cache {
 		});
 		return gwh;
 	}
-	
+
 	QueryService mockQueryService() throws RegionNotFoundException, IndexInvalidException, IndexNameConflictException, IndexExistsException, UnsupportedOperationException {
 		 
 		QueryService qs = mock(QueryService.class);
@@ -857,7 +853,7 @@ public class StubCache implements Cache {
 		 
 		return qs;
 	}
-	
+
 	@SuppressWarnings({ "rawtypes", "unchecked", "unused" })
 	Index mockIndex(String indexName, com.gemstone.gemfire.cache.query.IndexType indexType, String indexedExpression,
 			String fromClause, String imports){
@@ -876,14 +872,14 @@ public class StubCache implements Cache {
 		}
 		return idx;
 	}
-	
+
 	@SuppressWarnings("rawtypes")
 	public Map<String,Region> allRegions() {
 		return this.allRegions;
 	}
-	
+
 	public void setProperties(Properties props) {
 		this.properties = props;
 	}
-	
+
 }

--- a/src/test/resources/org/springframework/data/gemfire/config/RegionsWithDiskStoreAndPersistenceEvictionSettingsTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/RegionsWithDiskStoreAndPersistenceEvictionSettingsTest-context.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="
+	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+">
+
+	<gfe:cache/>
+
+	<gfe:disk-store id="DiskStoreOne" auto-compact="true" compaction-threshold="75">
+		<gfe:disk-dir location="." max-size="1024"/>
+	</gfe:disk-store>
+
+	<gfe:partitioned-region id="NotPersistentNoOverflowRegion" persistent="false" disk-store-ref="DiskStoreOne">
+	</gfe:partitioned-region>
+
+	<gfe:partitioned-region id="NotPersistentOverflowRegion" persistent="false" disk-store-ref="DiskStoreOne">
+		<gfe:eviction action="OVERFLOW_TO_DISK"/>
+	</gfe:partitioned-region>
+
+	<gfe:partitioned-region id="PersistentNoOverflowRegion" persistent="true" disk-store-ref="DiskStoreOne">
+		<gfe:eviction action="LOCAL_DESTROY"/>
+	</gfe:partitioned-region>
+
+	<gfe:partitioned-region id="PersistentOverflowRegion" persistent="true" disk-store-ref="DiskStoreOne">
+		<gfe:eviction action="OVERFLOW_TO_DISK"/>
+	</gfe:partitioned-region>
+
+</beans>


### PR DESCRIPTION
...DG to avoid setting the Disk Store Name on the RegionAttributes used to a create a Region in the RegionFactoryBean when the Region is neither 'persistent' nor has an Eviction policy of Overflow To Disk.  GemFire erroneousl throws an IllegalStateException when the Region references a Disk Store but is not configured with persistence or overflow, which should not matter.  Also fixed JIRA issues SGF-282 where the Eviction 'action' is ignored for PARTITION Regions when the 'threshold' is not set.
