### PR TITLE
Implements SGF-274 removing the use of temporary callback objects passed...

### DIFF
--- a/src/main/java/org/springframework/data/gemfire/GemfireAccessor.java
+++ b/src/main/java/org/springframework/data/gemfire/GemfireAccessor.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessException;
+import org.springframework.util.Assert;
 
 import com.gemstone.gemfire.GemFireCheckedException;
 import com.gemstone.gemfire.GemFireException;
@@ -31,18 +32,39 @@ import com.gemstone.gemfire.cache.Region;
  * Not intended to be used directly.
  * 
  * @author Costin Leau
+ * @author John Blum
+ * @see org.springframework.beans.factory.InitializingBean
+ * @see com.gemstone.gemfire.cache.Region
  */
 public class GemfireAccessor implements InitializingBean {
 
-	/** Logger available to subclasses */
 	protected final Log log = LogFactory.getLog(getClass());
 
-	private Region<?, ?> region;
+	private Region region;
+
+	/**
+	 * Returns the template GemFire Cache Region.
+	 *
+	 * @return the GemFire Cache Region.
+	 * @see com.gemstone.gemfire.cache.Region
+	 */
+	@SuppressWarnings("unchecked")
+	public <K, V> Region<K, V> getRegion() {
+		return region;
+	}
+
+	/**
+	 * Sets the template GemFire Cache Region.
+	 *
+	 * @param region the GemFire Cache Region used by this template.
+	 * @see com.gemstone.gemfire.cache.Region
+	 */
+	public void setRegion(Region<?, ?> region) {
+		this.region = region;
+	}
 
 	public void afterPropertiesSet() {
-		if (getRegion() == null) {
-			throw new IllegalArgumentException("Property 'region' is required");
-		}
+		Assert.notNull(getRegion(), "The GemFire Cache Region is required.");
 	}
 
 	/**
@@ -80,21 +102,4 @@ public class GemfireAccessor implements InitializingBean {
 		return GemfireCacheUtils.convertQueryExceptions(ex);
 	}
 
-	/**
-	 * Returns the template region.
-	 * 
-	 * @return the region
-	 */
-	public Region<?, ?> getRegion() {
-		return region;
-	}
-
-	/**
-	 * Sets the template region.
-	 * 
-	 * @param region the region to set
-	 */
-	public void setRegion(Region<?, ?> region) {
-		this.region = region;
-	}
 }

--- a/src/main/java/org/springframework/data/gemfire/GemfireCallback.java
+++ b/src/main/java/org/springframework/data/gemfire/GemfireCallback.java
@@ -26,19 +26,25 @@ import com.gemstone.gemfire.cache.Region;
  * operations on stored objects. 
  * 
  * @author Costin Leau
+ * @author John Blum
+ * @see com.gemstone.gemfire.cache.Region
  */
 public interface GemfireCallback<T> {
 
 	/**
-	 * Gets called by {@link GemfireTemplate#execute(GemfireCallback)}. Does not need to care about handling transactions
-	 * or exceptions.
+	 * Gets called by {@link GemfireTemplate#execute(GemfireCallback)}. Does not need to care about
+	 * handling transactions or exceptions.
 	 *
-	 * Allows for returning a result object created within the callback, i.e. a domain object or a collection of domain
-	 * objects. A thrown custom RuntimeException is treated as an application exception: It gets propagated to the caller
-	 * of the template.
+	 * Allows a result object created within the callback to be returned, i.e. a domain object
+	 * or a collection of domain objects.
+	 *
+	 * A thrown custom RuntimeException is treated as an application exception: it gets propagated to
+	 * the caller of the template.
 	 *  
-	 * @param region GemFire Region
-	 * @return a result object, or <tt>null</tt> if none
+	 * @param region a GemFire Cache Region.
+	 * @return a result object, or <tt>null</tt> if no result.
+	 * @see com.gemstone.gemfire.cache.Region
 	 */
 	T doInGemfire(Region<?,?> region) throws GemFireCheckedException, GemFireException;
+
 }

--- a/src/main/java/org/springframework/data/gemfire/GemfireOperations.java
+++ b/src/main/java/org/springframework/data/gemfire/GemfireOperations.java
@@ -25,97 +25,103 @@ import com.gemstone.gemfire.cache.query.SelectResults;
 
 /**
  * @author David Turanski
- *
+ * @author John Blum
  */
 public interface GemfireOperations {
 
-	public abstract boolean containsKey(Object key);
+	boolean containsKey(Object key);
 
-	public abstract boolean containsKeyOnServer(Object key);
+	boolean containsKeyOnServer(Object key);
 
-	public abstract boolean containsValue(Object value);
+	boolean containsValue(Object value);
 
-	public abstract boolean containsValueForKey(Object key);
+	boolean containsValueForKey(Object key);
 
-	public abstract <K, V> void create(K key, V value);
+	<K, V> void create(K key, V value);
 
-	public abstract <K, V> V get(K key);
+	<K, V> V get(K key);
 
-	public abstract <K, V> V put(K key, V value);
+	<K, V> Map<K, V> getAll(Collection<?> keys);
 
-	public abstract <K, V> V putIfAbsent(K key, V value);
+	<K, V> V put(K key, V value);
 
-	public abstract <K, V> V remove(K key);
+	<K, V> void putAll(Map<? extends K, ? extends V> map);
 
-	public abstract <K, V> V replace(K key, V value);
+	<K, V> V putIfAbsent(K key, V value);
 
-	public abstract <K, V> boolean replace(K key, V oldValue, V newValue);
+	<K, V> V replace(K key, V value);
 
-	public abstract <K, V> Map<K, V> getAll(Collection<?> keys);
+	<K, V> boolean replace(K key, V oldValue, V newValue);
 
-	public abstract <K, V> void putAll(Map<? extends K, ? extends V> map);
-
-	/**
-	 * Shortcut for {@link Region#query(String)} method. Filters the values of this region using the predicate given as a string with the syntax of the WHERE clause of the query language. 
-	 * The predefined variable this may be used inside the predicate to denote the current element being filtered. 
-	 * This method evaluates the passed in where clause and returns results. It is supported on servers as well as clients. 
-	 * When executed on a client, this method always runs on the server and returns results. 
-	 * When invoking this method from the client, applications can pass in a where clause or a complete query. 
-	
-	 * @see Region#query(String)
-	 * @param query A query language boolean query predicate. 
-	 * @return A SelectResults containing the values of this Region that match the predicate. 
-	 */
-	public abstract <E> SelectResults<E> query(String query);
+	<K, V> V remove(K key);
 
 	/**
 	 * Executes a GemFire query with the given (optional) parameters and returns the result. Note this method expects the query to return multiple results; for queries that return only one
 	 * element use {@link #findUnique(String, Object...)}.
 	 *
 	 * As oppose, to the {@link #query(String)} method, this method allows for more generic queries (against multiple regions even) to be executed.
-	 * 
+	 *
 	 * Note that the local query service is used if the region is configured as a client without any pool configuration or server connectivity - otherwise the query service on the default pool
 	 * is being used.
-	 * 
+	 *
 	 * @see QueryService#newQuery(String)
 	 * @see Query#execute(Object[])
 	 * @see SelectResults
 	 * @param query GemFire query
-	 * @param params Values that are bound to parameters (such as $1) in this query. 
+	 * @param params Values that are bound to parameters (such as $1) in this query.
 	 * @return A {@link SelectResults} instance holding the objects matching the query
 	 * @throws InvalidDataAccessApiUsageException in case the query returns a single result (not a {@link SelectResults}).
 	 */
-	public abstract <E> SelectResults<E> find(String query, Object... params) throws InvalidDataAccessApiUsageException;
+	<E> SelectResults<E> find(String query, Object... params) throws InvalidDataAccessApiUsageException;
 
 	/**
 	 * Executes a GemFire query with the given (optional) parameters and returns the result. Note this method expects the query to return a single result; for queries that return multiple
 	 * elements use {@link #find(String, Object...)}.
 	 *
 	 * As oppose, to the {@link #query(String)} method, this method allows for more generic queries (against multiple regions even) to be executed.
-	 * 
+	 *
 	 * Note that the local query service is used if the region is configured as a client without any pool configuration or server connectivity - otherwise the query service on the default pool
 	 * is being used.
-	 * 
+	 *
 	 * @see QueryService#newQuery(String)
 	 * @see Query#execute(Object[])
 	 * @param query GemFire query
 	 * @param params Values that are bound to parameters (such as $1) in this query.
 	 * @return The (single) object that represents the result of the query.
-	 * @throws InvalidDataAccessApiUsageException in case the query returns multiple objects (through {@link SelectResults}). 
+	 * @throws InvalidDataAccessApiUsageException in case the query returns multiple objects (through {@link SelectResults}).
 	 */
-	public abstract <T> T findUnique(String query, Object... params) throws InvalidDataAccessApiUsageException;
-
-	public abstract <T> T execute(GemfireCallback<T> action) throws DataAccessException;
+	<T> T findUnique(String query, Object... params) throws InvalidDataAccessApiUsageException;
 
 	/**
-	 * Execute the action specified by the given action object within a
-	 * Region.
-	 * @param action callback object that specifies the Gemfire action
-	 * @param exposeNativeRegion whether to expose the native
-	 * GemFire region to callback code
-	 * @return a result object returned by the action, or <code>null</code>
-	 * @throws org.springframework.dao.DataAccessException in case of GemFire errors
+	 * Shortcut for {@link Region#query(String)} method. Filters the values of this region using the predicate given as a string with the syntax of the WHERE clause of the query language.
+	 * The predefined variable this may be used inside the predicate to denote the current element being filtered.
+	 * This method evaluates the passed in where clause and returns results. It is supported on servers as well as clients.
+	 * When executed on a client, this method always runs on the server and returns results.
+	 * When invoking this method from the client, applications can pass in a where clause or a complete query.
+
+	 * @see Region#query(String)
+	 * @param query A query language boolean query predicate.
+	 * @return A SelectResults containing the values of this Region that match the predicate.
 	 */
-	public abstract <T> T execute(GemfireCallback<T> action, boolean exposeNativeRegion) throws DataAccessException;
+	<E> SelectResults<E> query(String query);
+
+	/**
+	 * Execute the action specified by the given action object within a Region.
+	 *
+	 * @param action callback object that specifies the Gemfire action to execute.
+	 * @return a result object returned by the action, or <code>null</code>.
+	 * @throws org.springframework.dao.DataAccessException in case of GemFire errors.
+	 */
+	<T> T execute(GemfireCallback<T> action) throws DataAccessException;
+
+	/**
+	 * Execute the action specified by the given action object within a Region.
+	 *
+	 * @param action callback object that specifies the Gemfire action to execute.
+	 * @param exposeNativeRegion whether to expose the native GemFire region to callback code.
+	 * @return a result object returned by the action, or <code>null</code>.
+	 * @throws org.springframework.dao.DataAccessException in case of GemFire errors.
+	 */
+	<T> T execute(GemfireCallback<T> action, boolean exposeNativeRegion) throws DataAccessException;
 
 }

--- a/src/test/java/org/springframework/data/gemfire/GemfireTemplateIntegrationTest.java
+++ b/src/test/java/org/springframework/data/gemfire/GemfireTemplateIntegrationTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2010-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.gemfire;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Resource;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.gemfire.repository.sample.User;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.gemstone.gemfire.cache.Region;
+import com.gemstone.gemfire.cache.query.SelectResults;
+
+/**
+ * The GemfireTemplateIntegrationTest class is a test suite of test cases testing the contract and functionality
+ * of the SDG GemfireTemplate class for wrapping a GemFire Cache Region and performing Cache Region operations.
+ *
+ * @author John Blum
+ * @see org.junit.Test
+ * @see org.springframework.data.gemfire.GemfireTemplate
+ * @see org.springframework.test.context.ContextConfiguration
+ * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+ * @since 1.4.0
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@SuppressWarnings("unused")
+public class GemfireTemplateIntegrationTest {
+
+	protected static final List<User> TEST_USER_LIST = new ArrayList<User>(11);
+
+	static {
+		TEST_USER_LIST.add(createUser("jonDoe"));
+		TEST_USER_LIST.add(createUser("janeDoe", false));
+		TEST_USER_LIST.add(createUser("pieDoe", false));
+		TEST_USER_LIST.add(createUser("cookieDoe"));
+		TEST_USER_LIST.add(createUser("jackHandy"));
+		TEST_USER_LIST.add(createUser("mandyHandy", false));
+		TEST_USER_LIST.add(createUser("randyHandy", false));
+		TEST_USER_LIST.add(createUser("sandyHandy"));
+		TEST_USER_LIST.add(createUser("imaPigg"));
+	}
+
+	@Resource(name = "Users")
+	private Region<String, User> users;
+
+	@Autowired
+	private GemfireTemplate usersTemplate;
+
+	protected static User createUser(final String username) {
+		return createUser(username, true);
+	}
+
+	protected static User createUser(final String username, final Boolean active) {
+		return createUser(username, String.format("%1$s@companyx.com", username), Calendar.getInstance(), active);
+	}
+
+	protected static User createUser(final String username, final String email, final Calendar since, final Boolean active) {
+		User user = new User(username);
+		user.setActive(Boolean.TRUE.equals(active));
+		user.setEmail(email);
+		user.setSince(since);
+		return user;
+	}
+
+	protected String getKey(final User user) {
+		return (user != null ? user.getUsername() : null);
+	}
+
+	protected User getUser(final String username) {
+		for (User user : TEST_USER_LIST) {
+			if (user.getUsername().equals(username)) {
+				return user;
+			}
+		}
+
+		return null;
+	}
+
+	protected List<User> getUsers(final String... usernames) {
+		List<User> users = new ArrayList<User>(usernames.length);
+		List<String> usernameList = Arrays.asList(usernames);
+
+		for (User user : TEST_USER_LIST) {
+			if (usernameList.contains(user.getUsername())) {
+				users.add(user);
+			}
+		}
+
+		return users;
+	}
+
+	protected Map<String, User> getUsersAsMap(final User... users) {
+		Map<String, User> userMap = new HashMap<String, User>(users.length);
+
+		for (User user : users) {
+			userMap.put(getKey(user), user);
+		}
+
+		return userMap;
+	}
+
+	protected void assertNullEquals(final Object value1, final Object value2) {
+		Assert.assertTrue(value1 == null ? value2 == null : value1.equals(value2));
+	}
+
+	@Before
+	public void setup() {
+		assertNotNull("The 'Users' Region was not properly configured and initialized!", users);
+
+		if (users.isEmpty()) {
+			for (User user : TEST_USER_LIST) {
+				users.put(getKey(user), user);
+			}
+
+			assertFalse(users.isEmpty());
+			assertEquals(TEST_USER_LIST.size(), users.size());
+		}
+	}
+
+	@Test
+	public void testContainsKey() {
+		assertTrue(usersTemplate.containsKey(getKey(getUser("jonDoe"))));
+		assertFalse(usersTemplate.containsKey("dukeNukem"));
+	}
+
+	@Test
+	@Ignore
+	public void testContainsKeyOnServer() {
+		assertTrue(usersTemplate.containsKeyOnServer(getKey(getUser("jackHandy"))));
+		assertFalse(usersTemplate.containsKeyOnServer("maxPayne"));
+	}
+
+	@Test
+	public void testContainsValue() {
+		assertTrue(usersTemplate.containsValue(getUser("pieDoe")));
+		assertFalse(usersTemplate.containsValue(createUser("pieDough")));
+	}
+
+	@Test
+	public void testContainsValueForKey() {
+		assertTrue(usersTemplate.containsValueForKey(getKey(getUser("cookieDoe"))));
+		assertFalse(usersTemplate.containsValueForKey("chocolateChipCookieDoe"));
+	}
+
+	@Test
+	public void testCreate() {
+		User bartSimpson = createUser("bartSimpson");
+
+		usersTemplate.create(getKey(bartSimpson), bartSimpson);
+
+		assertTrue(users.containsKey(getKey(bartSimpson)));
+		assertTrue(users.containsValueForKey(getKey(bartSimpson)));
+		assertTrue(users.containsValue(bartSimpson));
+		assertEquals(bartSimpson, users.get(getKey(bartSimpson)));
+	}
+
+	@Test
+	public void testGet() {
+		assertEquals(users.get(getKey(getUser("imaPigg"))), usersTemplate.get(getKey(getUser("imaPigg"))));
+		assertNullEquals(users.get("mrT"), usersTemplate.get("mrT"));
+	}
+
+	@Test
+	public void testPut() {
+		User peterGriffon = createUser("peterGriffon");
+
+		assertNull(usersTemplate.put(getKey(peterGriffon), peterGriffon));
+		assertEquals(peterGriffon, users.get(getKey(peterGriffon)));
+	}
+
+	@Test
+	public void testPutIfAbsent() {
+		User stewieGriffon = createUser("stewieGriffon");
+
+		assertFalse(users.containsValue(stewieGriffon));
+		assertNull(usersTemplate.putIfAbsent(getKey(stewieGriffon), stewieGriffon));
+		assertTrue(users.containsValue(stewieGriffon));
+		assertEquals(stewieGriffon, usersTemplate.putIfAbsent(getKey(stewieGriffon), createUser("megGriffon")));
+		assertEquals(stewieGriffon, users.get(getKey(stewieGriffon)));
+	}
+
+	@Test
+	public void testRemove() {
+		User mandyHandy = users.get(getKey(getUser("mandyHandy")));
+
+		assertNotNull(mandyHandy);
+		assertEquals(mandyHandy, usersTemplate.remove(getKey(mandyHandy)));
+		assertFalse(users.containsKey(getKey(mandyHandy)));
+		assertFalse(users.containsValue(mandyHandy));
+		assertFalse(users.containsKey("loisGriffon"));
+		assertNull(usersTemplate.remove("loisGriffon"));
+		assertFalse(users.containsKey("loisGriffon"));
+	}
+
+	@Test
+	public void testReplace() {
+		User randyHandy = users.get(getKey(getUser("randyHandy")));
+		User lukeFluke = createUser("lukeFluke");
+		User chrisGriffon = createUser("chrisGriffon");
+
+		assertNotNull(randyHandy);
+		assertEquals(randyHandy, usersTemplate.replace(getKey(randyHandy), lukeFluke));
+		assertEquals(lukeFluke, users.get(getKey(randyHandy)));
+		assertFalse(users.containsValue(randyHandy));
+		assertFalse(users.containsValue(chrisGriffon));
+		assertNull(usersTemplate.replace(getKey(chrisGriffon), chrisGriffon));
+		assertFalse(users.containsValue(chrisGriffon));
+	}
+
+	@Test
+	public void testReplaceOldValueWithNewValue() {
+		User jackHandy = getUser("jackHandy");
+		User imaPigg = getUser("imaPigg");
+
+		assertTrue(users.containsValue(jackHandy));
+		assertFalse(usersTemplate.replace(getKey(jackHandy), null, imaPigg));
+		assertTrue(users.containsValue(jackHandy));
+		assertEquals(jackHandy, users.get(getKey(jackHandy)));
+		assertTrue(usersTemplate.replace(getKey(jackHandy), jackHandy, imaPigg));
+		assertFalse(users.containsValue(jackHandy));
+		assertEquals(imaPigg, users.get(getKey(jackHandy)));
+	}
+
+	@Test
+	public void testGetAllReturnsNoResults() {
+		List<String> keys = Arrays.asList("keyOne", "keyTwo", "keyThree");
+
+		Map<String, User> actualUserMapping = usersTemplate.getAll(keys);
+		Map<String, User> expectedUserMapping = users.getAll(keys);
+
+		assertEquals(expectedUserMapping, actualUserMapping);
+	}
+
+	@Test
+	public void testGetAllReturnsResults() {
+		List<String> keys = Arrays.asList(getKey(getUser("jonDoe")), getKey(getUser("pieDoe")));
+
+		Map<String, User> actualUserMapping = usersTemplate.getAll(keys);
+		Map<String, User> expectedUserMapping = users.getAll(keys);
+
+		assertEquals(actualUserMapping, expectedUserMapping);
+	}
+
+	@Test
+	public void testPutAll() {
+		User batMan = createUser("batMap");
+		User spiderMan = createUser("spiderMan");
+		User superMan = createUser("superMan");
+
+		Map<String, User> userMap = getUsersAsMap(batMan, spiderMan, superMan);
+
+		assertFalse(users.keySet().containsAll(userMap.keySet()));
+		assertFalse(users.values().containsAll(userMap.values()));
+
+		usersTemplate.putAll(userMap);
+
+		assertTrue(users.keySet().containsAll(userMap.keySet()));
+		assertTrue(users.values().containsAll(userMap.values()));
+	}
+
+	@Test
+	public void testQuery() {
+		SelectResults<User> queryResults = usersTemplate.query("username LIKE '%Doe'");
+
+		assertNotNull(queryResults);
+
+		List<User> queriedUsers = queryResults.asList();
+
+		assertNotNull(queriedUsers);
+		assertFalse(queriedUsers.isEmpty());
+		assertEquals(4, queriedUsers.size());
+		assertTrue(queriedUsers.containsAll(getUsers("jonDoe", "janeDoe", "pieDoe", "cookieDoe")));
+	}
+
+	@Test
+	public void testFind() {
+		SelectResults<User> findResults = usersTemplate.find("SELECT u FROM /Users u WHERE u.username LIKE $1 AND u.active = $2", "%Doe", true);
+
+		assertNotNull(findResults);
+
+		List<User> usersFound = findResults.asList();
+
+		assertNotNull(usersFound);
+		assertFalse(usersFound.isEmpty());
+		assertEquals(2, usersFound.size());
+		assertTrue(usersFound.containsAll(getUsers("jonDoe", "cookieDoe")));
+	}
+
+	@Test
+	public void testFindUniqueReturnsResult() {
+		User jonDoe = usersTemplate.findUnique("SELECT u FROM /Users u WHERE u.username = $1", "jonDoe");
+
+		assertNotNull(jonDoe);
+		assertEquals(getUser("jonDoe"), jonDoe);
+	}
+
+	@Test(expected = InvalidDataAccessApiUsageException.class)
+	public void testFindUniqueReturnsNoResult() {
+		usersTemplate.findUnique("SELECT u FROM /Users u WHERE u.username = $1", "benDover");
+	}
+
+}

--- a/src/test/resources/org/springframework/data/gemfire/GemfireTemplateIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/GemfireTemplateIntegrationTest-context.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
+	   xmlns:p="http://www.springframework.org/schema/p"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+">
+
+	<util:properties id="gemfireCacheConfigurationSettings">
+		<prop key="name">GemfireTemplateIntegrationTest</prop>
+		<prop key="mcast-port">0</prop>
+		<prop key="log-level">config</prop>
+	</util:properties>
+
+	<gfe:cache properties-ref="gemfireCacheConfigurationSettings"/>
+
+	<gfe:replicated-region id="Users" persistent="false"/>
+
+	<bean id="template" class="org.springframework.data.gemfire.GemfireTemplate" p:region-ref="Users"/>
+
+</beans>

--- a/src/test/resources/org/springframework/data/gemfire/basic-template.xml
+++ b/src/test/resources/org/springframework/data/gemfire/basic-template.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:gfe="http://www.springframework.org/schema/gemfire"
-	xsi:schemaLocation="http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
-		default-lazy-init="true">
+	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
+	   xmlns:p="http://www.springframework.org/schema/p"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+">
 
-	<gfe:cache />
-	
-	<gfe:replicated-region id="simple" />
-	
-	<bean id="template" class="org.springframework.data.gemfire.GemfireTemplate">
-		<property name="region" ref="simple"/>
-	</bean>
-		
+	<gfe:cache/>
+
+	<gfe:replicated-region id="simple"/>
+
+	<bean id="template" class="org.springframework.data.gemfire.GemfireTemplate" p:region-ref="simple"/>
+
 </beans>


### PR DESCRIPTION
... to the 'templated' execute method for each operation implementation in order to reduce the memory footprint, especially in the context of Repositories.
