### PR TITLE
Add the Spring IO plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.4'
+        classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
     }
 }
 
@@ -24,9 +25,21 @@ apply from: "$rootDir/maven.gradle"
 apply plugin: 'docbook-reference'
 //apply plugin: 'bundlor'
 
+if (project.hasProperty('platformVersion')) {
+   apply plugin: 'spring-io'
+
+    repositories {
+        maven { url "https://repo.spring.io/libs-snapshot" }
+    }
+
+    dependencies {
+      springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+    }
+}
+
 [compileJava, compileTestJava]*.options*.compilerArgs = ["-Xlint:-serial"]
 
-test {
+tasks.withType(Test).all {
     forkEvery = 1
     systemProperties['gemfire.disableShutdownHook'] = 'true'
     systemProperties['org.springframework.data.gemfire.test.GemfireTestRunner.nomock'] = System.getProperty('org.springframework.data.gemfire.test.GemfireTestRunner.nomock')


### PR DESCRIPTION
Configure the Spring IO plugin such that it's only applied when the build is run with `-PplatformVersion=<version>`. This `platformVersion` property is used to determine the version of the Platform that will
be used when running the `springIoCheck` task. The plugin can be used by running a build as follows:

```
./gradlew clean springIoCheck -PplatformVersion=1.0.0.BUILD-SNAPSHOT -PJDK7_HOME=… -PJDK8_HOME=…
```

This will test the project on JDK 7 and JDK 8 using the dependencies defined in the latest snapshot of Spring IO Platform 1.0.0.
