### PR TITLE
adding appinfo hint to help ide figure out that the client-region ele…

### DIFF
--- a/src/main/resources/org/springframework/data/gemfire/config/spring-gemfire-1.8.xsd
+++ b/src/main/resources/org/springframework/data/gemfire/config/spring-gemfire-1.8.xsd
@@ -2177,7 +2177,18 @@ Defines a template for creating multiple GemFire Client Regions that all share a
 		</xsd:annotation>
 	</xsd:element>
 	<!-- -->
-	<xsd:element name="client-region" type="clientRegionType"/>
+	<xsd:element name="client-region" type="clientRegionType">
+		<xsd:annotation>
+			<xsd:documentation source="org.springframework.data.gemfire.ClientRegionFactoryBean"><![CDATA[
+Defines a GemFire Client Region
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="com.gemstone.gemfire.cache.Region"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+	</xsd:element>
 	<!-- -->
 	<xsd:complexType name="connectionType">
 		<xsd:attribute name="host" type="xsd:string">


### PR DESCRIPTION
…ment produces beans of type Region, without which intellij tells me it can't parse this 'custom spring bean'

hello,

when i use gemfire and setup a client region using the spring gemfire namespace, intellij idea tells me that it cannot parse this custom spring bean.  as far as i can tell i have this problem only with the <gfe:client-region> element.

i had a look at the xsd and noticed that the element definition does not sport the appinfo hint that tells applications that it exports a bean of type Region.

this pull request fixes this issue and makes my ide happy.

this blog does a good job of explaining the issue:

http://blog.trifork.com/2011/07/07/enhancing-ide-support-for-custom-spring-namespace-elements/