### PR TITLE
SGF-477 - Change compile dependency from gemfire-core to geode-core.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 	}
 
 	// Apache Geode (a.k.a. Pivotal GemFire)
-	compile("org.apache.geode:gemfire-core:$gemfireVersion") {
+	compile("org.apache.geode:geode-core:$gemfireVersion") {
 		exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
 		exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
 		exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"


### PR DESCRIPTION
Geode has renamed the archive to be geode-core. Changing SDG's
dependencies to match.