### PR TITLE
SGF-582 support 'id' property as a region key when saving, Gregory Gr…

### DIFF
--- a/src/test/java/org/springframework/data/gemfire/GenericRegionFactoryBeanTest.java
+++ b/src/test/java/org/springframework/data/gemfire/GenericRegionFactoryBeanTest.java
@@ -18,6 +18,9 @@ package org.springframework.data.gemfire;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.springframework.data.gemfire.test.support.FileSystemUtils.FileExtensionFilter.newFileExtensionFilter;
+
+import java.io.FileFilter;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -27,18 +30,20 @@ import org.apache.geode.cache.Scope;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.springframework.data.gemfire.test.support.FileSystemUtils;
+import org.springframework.data.gemfire.util.CacheUtils;
 
 /**
- * The GenericRegionFactoryBeanTest class is a test suite of test cases testing the contract and functionality
- * of the GenericRegionFactoryBean class.
+ * Unit tests for {@link GenericRegionFactoryBean}.
  *
  * @author John Blum
+ * @see org.junit.Test
  * @see org.springframework.data.gemfire.GenericRegionFactoryBean
  * @since 1.7.0
  */
 public class GenericRegionFactoryBeanTest {
 
-	// as defined in the org.apache.geode.internal.cache.AbstractRegion class
+	// As defined in com.gemstone.gemfire.internal.cache.AbstractRegion
 	private static final Scope DEFAULT_SCOPE = Scope.DISTRIBUTED_NO_ACK;
 
 	private static Region<Object, Object> defaultRegion;
@@ -120,21 +125,25 @@ public class GenericRegionFactoryBeanTest {
 
 	@AfterClass
 	public static void tearDown() {
-		try {
-			CacheFactory.getAnyInstance().close();
-		}
-		catch (Exception ignore) {
-		}
+		CacheUtils.closeCache();
+
+		FileFilter fileFilter = FileSystemUtils.CompositeFileFilter.or(
+			newFileExtensionFilter(".if"), newFileExtensionFilter(".crf"), newFileExtensionFilter(".drf"),
+				newFileExtensionFilter(".log"));
+
+		FileSystemUtils.deleteRecursive(FileSystemUtils.WORKING_DIRECTORY, fileFilter);
 	}
 
 	protected void assertRegionAttributes(Region<?, ?> region, String expectedRegionName, DataPolicy expectedDataPolicy,
 			Scope expectedScope) {
+
 		assertRegionAttributes(region, expectedRegionName, String.format("%1$s%2$s", Region.SEPARATOR, expectedRegionName),
 			expectedDataPolicy, expectedScope);
 	}
 
 	protected void assertRegionAttributes(Region<?, ?> region, String expectedRegionName, String expectedRegionPath,
 			DataPolicy expectedDataPolicy, Scope expectedScope) {
+
 		assertNotNull("The GemFire Cache Region must not be null!", region);
 		assertEquals(expectedRegionName, region.getName());
 		assertEquals(expectedRegionPath, region.getFullPath());
@@ -178,5 +187,4 @@ public class GenericRegionFactoryBeanTest {
 	public void replicateRegionAttributes() {
 		assertRegionAttributes(replicateRegion, "ReplicateRegion", DataPolicy.REPLICATE, Scope.GLOBAL);
 	}
-
 }

--- a/src/test/java/org/springframework/data/gemfire/mapping/GemfirePersistentEntityUnitTests.java
+++ b/src/test/java/org/springframework/data/gemfire/mapping/GemfirePersistentEntityUnitTests.java
@@ -23,10 +23,14 @@ import static org.junit.Assert.assertThat;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.data.gemfire.mapping.annotation.Region;
+import org.springframework.data.mapping.IdentifierAccessor;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.util.ClassTypeInformation;
+
+import lombok.Data;
 
 /**
  * Unit tests for {@link GemfirePersistentEntity}.
@@ -38,6 +42,36 @@ public class GemfirePersistentEntityUnitTests {
 
 	protected MappingContext<GemfirePersistentEntity<?>, GemfirePersistentProperty> getMappingContext() {
 		return new GemfireMappingContext();
+	}
+
+	/**
+	 * JIRA ticket SGF-582
+	 * 
+	 * Used an object's getId method if the @Id does not exists
+	 */
+	@Test
+	public void supportsGetId() {
+		
+		GemfirePersistentEntity<UnannotatedRegion> unnamedRegionEntity = new GemfirePersistentEntity<UnannotatedRegion>(
+				ClassTypeInformation.from(UnannotatedRegion.class));
+
+		IdentifierAccessor accessor = unnamedRegionEntity.getIdentifierAccessor(new UnannotatedRegion());
+		Assert.assertNull(accessor.getIdentifier());
+
+		GemfirePersistentEntity<NotAnnotationIdRegion> entity = new GemfirePersistentEntity<NotAnnotationIdRegion>(
+				ClassTypeInformation.from(NotAnnotationIdRegion.class));
+		
+		NotAnnotationIdRegion region = new NotAnnotationIdRegion();
+
+		region.setId("id");
+		region.setValue("value");
+
+		accessor = entity.getIdentifierAccessor(region);
+
+		Assert.assertNotNull(accessor.getIdentifier());
+
+		Assert.assertEquals("id", accessor.getIdentifier());
+
 	}
 
 	@Test
@@ -65,8 +99,8 @@ public class GemfirePersistentEntityUnitTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void bigDecimalPersistentPropertyIsNotEntity() {
-		GemfirePersistentEntity<ExampleDomainObject> entity = (GemfirePersistentEntity<ExampleDomainObject>)
-			getMappingContext().getPersistentEntity(ExampleDomainObject.class);
+		GemfirePersistentEntity<ExampleDomainObject> entity = (GemfirePersistentEntity<ExampleDomainObject>) getMappingContext()
+				.getPersistentEntity(ExampleDomainObject.class);
 
 		assertThat(entity.getRegionName(), is(equalTo("Example")));
 
@@ -79,8 +113,8 @@ public class GemfirePersistentEntityUnitTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void bigIntegerPersistentPropertyIsNotEntity() {
-		GemfirePersistentEntity<ExampleDomainObject> entity = (GemfirePersistentEntity<ExampleDomainObject>)
-			getMappingContext().getPersistentEntity(ExampleDomainObject.class);
+		GemfirePersistentEntity<ExampleDomainObject> entity = (GemfirePersistentEntity<ExampleDomainObject>) getMappingContext()
+				.getPersistentEntity(ExampleDomainObject.class);
 
 		assertThat(entity.getRegionName(), is(equalTo("Example")));
 
@@ -90,15 +124,18 @@ public class GemfirePersistentEntityUnitTests {
 		assertThat(bigNumber.isEntity(), is(false));
 	}
 
-	static class UnannotatedRegion {
-	}
+	static class UnannotatedRegion {}
 
 	@Region("Foo")
-	static class AnnotatedRegion {
-	}
+	static class AnnotatedRegion {}
 
 	@Region
-	static class UnnamedRegion {
+	static class UnnamedRegion {}
+
+	static @Data class NotAnnotationIdRegion {
+
+		private String value;
+		private String id;
 	}
 
 	@Region("Example")

--- a/src/test/java/org/springframework/data/gemfire/test/support/FileSystemUtils.java
+++ b/src/test/java/org/springframework/data/gemfire/test/support/FileSystemUtils.java
@@ -16,6 +16,9 @@
 
 package org.springframework.data.gemfire.test.support;
 
+import static org.springframework.data.gemfire.util.ArrayUtils.nullSafeArray;
+import static org.springframework.data.gemfire.util.CollectionUtils.nullSafeIterable;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.util.ArrayList;
@@ -25,8 +28,8 @@ import java.util.List;
 import org.springframework.util.Assert;
 
 /**
- * The FileSystemUtils class is a utility class encapsulating functionality to process file system directories
- * and files collectively.
+ * The {@link FileSystemUtils} class is a utility class encapsulating functionality to process
+ * file system directories and files collectively.
  *
  * @author John Blum
  * @see java.io.File
@@ -40,14 +43,23 @@ public abstract class FileSystemUtils extends FileUtils {
 
 	public static final File JAVA_HOME = new File(System.getProperty("java.home"));
 	public static final File JAVA_EXE = new File(new File(JAVA_HOME, "bin"), "java");
+	public static final File TEMPORARY_DIRECTORY = new File(System.getProperty("java.io.tmpdir"));
 	public static final File USER_HOME = new File(System.getProperty("user.home"));
 	public static final File WORKING_DIRECTORY = new File(System.getProperty("user.dir"));
 
+	public static final File[] NO_FILES = new File[0];
+
+	/* (non-Javadoc) */
 	public static boolean deleteRecursive(File path) {
+		return deleteRecursive(path, AllFilesFilter.INSTANCE);
+	}
+
+	/* (non-Javadoc) */
+	public static boolean deleteRecursive(File path, FileFilter fileFilter) {
 		boolean success = true;
 
 		if (isDirectory(path)) {
-			for (File file : safeListFiles(path)) {
+			for (File file : safeListFiles(path, fileFilter)) {
 				success &= deleteRecursive(file);
 			}
 		}
@@ -68,9 +80,10 @@ public abstract class FileSystemUtils extends FileUtils {
 		return (localPath != null ? localPath : path);
 	}
 
+	/* (non-Javadoc) */
 	public static File[] listFiles(File directory, FileFilter fileFilter) {
-		Assert.isTrue(isDirectory(directory), String.format( "File (%1$s) does not refer to a valid directory",
-			directory));
+		Assert.isTrue(isDirectory(directory), String.format(
+			"File [%s] does not refer to a valid directory", directory));
 
 		List<File> results = new ArrayList<File>();
 
@@ -86,43 +99,147 @@ public abstract class FileSystemUtils extends FileUtils {
 		return results.toArray(new File[results.size()]);
 	}
 
+	/* (non-Javadoc) */
 	public static File[] safeListFiles(File directory) {
-		return safeListFiles(directory, AllFiles.INSTANCE);
+		return safeListFiles(directory, AllFilesFilter.INSTANCE);
 	}
 
+	/* (non-Javadoc) */
 	public static File[] safeListFiles(File directory, FileFilter fileFilter) {
-		File[] files = (directory != null ? directory.listFiles(fileFilter) : null);
-		return (files != null ? files : new File[0]);
+		FileFilter resolvedFileFilter = (fileFilter != null ? fileFilter : AllFilesFilter.INSTANCE);
+		File[] files = (isDirectory(directory) ? directory.listFiles(resolvedFileFilter) : null);
+		return (files != null ? files : NO_FILES);
 	}
 
-	public static final class AllFiles implements FileFilter {
+	public static class AllFilesFilter implements FileFilter {
 
-		public static final AllFiles INSTANCE = new AllFiles();
+		public static final AllFilesFilter INSTANCE = new AllFilesFilter();
 
 		@Override
-		public boolean accept(final File pathname) {
+		public boolean accept(File pathname) {
 			return true;
 		}
 	}
 
-	public static final class FileOnlyFilter implements FileFilter {
+	public static class CompositeFileFilter implements FileFilter {
 
-		public static final FileOnlyFilter INSTANCE = new FileOnlyFilter();
+		private final FileFilter fileFilterOne;
+		private final FileFilter fileFilterTwo;
+
+		private final LogicalOperator logicalOperator;
+
+		private CompositeFileFilter(FileFilter fileFilterOne, LogicalOperator operator, FileFilter fileFilterTwo) {
+			this.fileFilterOne = fileFilterOne;
+			this.logicalOperator = operator;
+			this.fileFilterTwo = fileFilterTwo;
+		}
+
+		protected static FileFilter compose(FileFilter fileFilterOne, LogicalOperator operator, FileFilter fileFilterTwo) {
+			return (fileFilterOne == null ? fileFilterTwo : (fileFilterTwo == null ? fileFilterOne
+				: new CompositeFileFilter(fileFilterOne, operator, fileFilterTwo)));
+		}
+
+		public static FileFilter and(FileFilter... fileFilters) {
+			return and(Arrays.asList(nullSafeArray(fileFilters, FileFilter.class)));
+		}
+
+		public static FileFilter and(Iterable<FileFilter> fileFilters) {
+			FileFilter current = null;
+
+			for (FileFilter fileFilter : nullSafeIterable(fileFilters)) {
+				current = compose(current, LogicalOperator.AND, fileFilter);
+			}
+
+			return current;
+		}
+
+		public static FileFilter or(FileFilter... fileFilters) {
+			return or(Arrays.asList(nullSafeArray(fileFilters, FileFilter.class)));
+		}
+
+		public static FileFilter or(Iterable<FileFilter> fileFilters) {
+			FileFilter current = null;
+
+			for (FileFilter fileFilter : nullSafeIterable(fileFilters)) {
+				current = compose(current, LogicalOperator.OR, fileFilter);
+			}
+
+			return current;
+		}
 
 		@Override
-		public boolean accept(final File pathname) {
-			return (pathname != null && pathname.isFile());
+		public boolean accept(File pathname) {
+			switch (this.logicalOperator) {
+				case AND:
+					return (fileFilterOne.accept(pathname) && fileFilterTwo.accept(pathname));
+				case OR:
+					return (fileFilterOne.accept(pathname) || fileFilterTwo.accept(pathname));
+				default:
+					throw new UnsupportedOperationException(String.format(
+						"Logical operator [%s] is unsupported", this.logicalOperator));
+			}
+		}
+
+		enum LogicalOperator {
+			AND, OR;
 		}
 	}
 
-	public static final class DirectoryOnlyFilter implements FileFilter {
+	public static class DirectoryOnlyFilter implements FileFilter {
 
 		public static final DirectoryOnlyFilter INSTANCE = new DirectoryOnlyFilter();
 
 		@Override
-		public boolean accept(final File pathname) {
-			return (pathname != null && pathname.isDirectory());
+		public boolean accept(File pathname) {
+			return isDirectory(pathname);
 		}
 	}
 
+	public static final class FileExtensionFilter extends FileOnlyFilter {
+
+		private final String fileExtension;
+
+		public static FileExtensionFilter newFileExtensionFilter(String fileExtension) {
+			return new FileExtensionFilter(fileExtension);
+		}
+
+		public FileExtensionFilter(String fileExtension) {
+			Assert.hasText(fileExtension, String.format("File extension [%s] must be specified", fileExtension));
+			this.fileExtension = fileExtension;
+		}
+
+		@Override
+		public boolean accept(File pathname) {
+			return (super.accept(pathname) && pathname.getAbsolutePath().toLowerCase().endsWith(this.fileExtension));
+		}
+	}
+
+	public static class FileOnlyFilter implements FileFilter {
+
+		public static final FileOnlyFilter INSTANCE = new FileOnlyFilter();
+
+		@Override
+		public boolean accept(File pathname) {
+			return isFile(pathname);
+		}
+	}
+
+	public static class NegatingFileFilter implements FileFilter {
+
+		private final FileFilter delegate;
+
+		public static NegatingFileFilter newNegatingFileFilter(FileFilter delegate) {
+			return new NegatingFileFilter(delegate);
+		}
+
+		public NegatingFileFilter(FileFilter delegate) {
+			Assert.notNull(delegate, "FileFilter must not be null");
+			this.delegate = delegate;
+		}
+
+		@Override
+		public boolean accept(File pathname) {
+			return !this.delegate.accept(pathname);
+		}
+	}
 }

--- a/src/test/java/org/springframework/data/gemfire/test/support/FileUtils.java
+++ b/src/test/java/org/springframework/data/gemfire/test/support/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 the original author or authors.
+ * Copyright 2010-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * The FileUtils class is a utility class for processing files, working with java.io.File objects.
+ * The {@link FileUtils} class is an abstract utility class for processing file system files
+ * by working with {@link File} objects.
  *
  * @author John Blum
  * @see java.io.File
@@ -39,20 +40,33 @@ import org.springframework.util.StringUtils;
 @SuppressWarnings("unused")
 public abstract class FileUtils extends IOUtils {
 
+	public static final String FILE_SEPARATOR = System.getProperty("file.separator");
 	public static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
-	public static boolean isDirectory(final File path) {
+	/* (non-Javadoc) */
+	public static boolean isDirectory(File path) {
 		return (path != null && path.isDirectory());
 	}
 
-	public static boolean isFile(final File path) {
+	/* (non-Javadoc) */
+	public static boolean isFile(File path) {
 		return (path != null && path.isFile());
 	}
 
+	/* (non-Javadoc) */
+	public static File newFile(String pathname) {
+		return new File(pathname);
+	}
+
+	/* (non-Javadoc) */
+	public static File newFile(File parent, String pathname) {
+		return new File(parent, pathname);
+	}
+
+	/* (non-Javadoc) */
 	@SuppressWarnings("all")
 	public static String read(File file) throws IOException {
-		Assert.isTrue(isFile(file), String.format(
-			"File [%1$s], from which to read the contents of, does not refer to a valid file", file));
+		Assert.isTrue(isFile(file), String.format("The file [%s] to read the contents from is not a valid file", file));
 
 		BufferedReader fileReader = new BufferedReader(new FileReader(file));
 
@@ -71,8 +85,9 @@ public abstract class FileUtils extends IOUtils {
 		}
 	}
 
+	/* (non-Javadoc) */
 	public static void write(File file, String contents) throws IOException {
-		Assert.notNull(file, "File must not be null!");
+		Assert.notNull(file, "File must not be null");
 
 		Assert.isTrue(StringUtils.hasText(contents), String.format(
 			"The contents for File [%1$s] cannot be null or empty", file));
@@ -88,5 +103,4 @@ public abstract class FileUtils extends IOUtils {
 			IOUtils.close(fileWriter);
 		}
 	}
-
 }

--- a/src/test/java/org/springframework/data/gemfire/test/support/IOUtils.java
+++ b/src/test/java/org/springframework/data/gemfire/test/support/IOUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 the original author or authors.
+ * Copyright 2010-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * The IOUtils class is an utility class working with IO operations.
+ * The {@link IOUtils} class is an abstract utility class for working with IO operations.
  *
  * @author John Blum
+ * @see java.io.Closeable
  * @since 1.5.0
  */
 @SuppressWarnings("unused")
@@ -32,6 +33,7 @@ public abstract class IOUtils {
 
 	protected static final Logger log = Logger.getLogger(IOUtils.class.getName());
 
+	/* (non-Javadoc) */
 	public static boolean close(Closeable closeable) {
 		if (closeable != null) {
 			try {
@@ -48,5 +50,4 @@ public abstract class IOUtils {
 
 		return false;
 	}
-
 }


### PR DESCRIPTION
This change supports using a bean property "id" as a region key if @Id annotation is not set. This feature is supported by other spring data projects, such as Spring Data Mongo.

See the following test cases (unit or integration tests) that back the changes.
- src/test/java/org/springframework/data/gemfire/mapping/GemfirePersistentEntityUnitTests.java

