### PR TITLE
When region not found, look for a Spring-registered Region Bean with the Region's name

### DIFF
--- a/src/main/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactory.java
@@ -29,11 +29,7 @@ import org.springframework.data.gemfire.GemfireTemplate;
 import org.springframework.data.gemfire.mapping.GemfirePersistentEntity;
 import org.springframework.data.gemfire.mapping.GemfirePersistentProperty;
 import org.springframework.data.gemfire.mapping.Regions;
-import org.springframework.data.gemfire.repository.query.DefaultGemfireEntityInformation;
-import org.springframework.data.gemfire.repository.query.GemfireEntityInformation;
-import org.springframework.data.gemfire.repository.query.GemfireQueryMethod;
-import org.springframework.data.gemfire.repository.query.PartTreeGemfireRepositoryQuery;
-import org.springframework.data.gemfire.repository.query.StringBasedGemfireRepositoryQuery;
+import org.springframework.data.gemfire.repository.query.*;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.NamedQueries;
@@ -119,14 +115,13 @@ public class GemfireRepositoryFactory extends RepositoryFactorySupport {
 
 		Region<?, ?> region = regions.getRegion(resolvedRegionName);
 
-		if (region ==  null && this._beanFactory != null) {
+		if (region == null && this._beanFactory != null) {
 			try {
 				region = this._beanFactory.getBean(resolvedRegionName, Region.class);
-			}
-			catch (NoSuchBeanDefinitionException nsbde) {
-				//ok to ignore this, region will remain null
-				//and the IllegalStateException will kick in
-				//and give an accurate message
+			} catch (NoSuchBeanDefinitionException nsbde) {
+				// ok to ignore this, region will remain null
+				// and the IllegalStateException will kick in
+				// and give an accurate message
 			}
 		}
 

--- a/src/main/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactory.java
@@ -128,9 +128,6 @@ public class GemfireRepositoryFactory extends RepositoryFactorySupport {
 				//and the IllegalStateException will kick in
 				//and give an accurate message
 			}
-			catch (Exception ex) {
-				ex.printStackTrace();
-			}
 		}
 
 		if (region == null) {

--- a/src/main/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/gemfire/repository/support/GemfireRepositoryFactory.java
@@ -119,7 +119,7 @@ public class GemfireRepositoryFactory extends RepositoryFactorySupport {
 
 		Region<?, ?> region = regions.getRegion(resolvedRegionName);
 
-		if (region ==  null) {
+		if (region ==  null && this._beanFactory != null) {
 			try {
 				region = this._beanFactory.getBean(resolvedRegionName, Region.class);
 			}


### PR DESCRIPTION
We have a need to pass the actual name of a Region to Spring at runtime.  For example, say we have an entity annotated with `@Region("MyRegion")`.  When running in development, we want our entity to persist to a region called 'MyRegion_dev', and similarly, persist to 'MyRegion_qa' when running in QA.  The `@Region` annotation doesn't support EL, so that's not an option.

The most logical solution in my opinion was to keep the existing logic as-is, so if a region named 'MyRegion' exists, use it.  However, if it doesn't exist, we could add one additional step to look for a Spring bean of type Region with the name 'MyRegion.'  This bean could be configured at startup time to point to any arbitrarily-named region using environment variables, Config Server, etc.



<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/SGF).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

