### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,12 +178,12 @@ javadoc {
       ]
 
       links = [
-        "http://docs.oracle.com/javase/6/docs/api/",
-        "http://docs.spring.io/spring/docs/current/javadoc-api/",
-        "http://docs.spring.io/spring-data-gemfire/docs/current/api/",
-        "http://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html",
-        "http://gemfire.docs.pivotal.io/docs-gemfire/latest/javadocs/japi/",
-        "http://logging.apache.org/log4j/1.2/apidocs/",
+        "https://docs.oracle.com/javase/6/docs/api/",
+        "https://docs.spring.io/spring/docs/current/javadoc-api/",
+        "https://docs.spring.io/spring-data-gemfire/docs/current/api/",
+        "https://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html",
+        "https://gemfire.docs.pivotal.io/docs-gemfire/latest/javadocs/japi/",
+        "https://logging.apache.org/log4j/1.2/apidocs/",
       ]
 
       exclude "org/springframework/data/gemfire/config/**"

--- a/maven.gradle
+++ b/maven.gradle
@@ -31,20 +31,20 @@ def customizePom(pom, gradleProject) {
         generatedPom.project {
             name = gradleProject.description
             description = gradleProject.description
-            url = 'http://github.com/SpringSource/spring-gemfire'
+            url = 'https://github.com/SpringSource/spring-gemfire'
             organization {
                 name = 'SpringSource'
-                url = 'http://www.springsource.org/spring-gemfire'
+                url = 'https://www.springsource.org/spring-gemfire'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }
             scm {
-                url = 'http://github.com/SpringSource/spring-gemfire'
+                url = 'https://github.com/SpringSource/spring-gemfire'
                 connection = 'scm:git:git://github.com/SpringSource/spring-gemfire'
                 developerConnection = 'scm:git:git://github.com/SpringSource/spring-gemfire'
             }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/samples/hello-world/build.gradle
+++ b/samples/hello-world/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'application'
 
 repositories {
     // Public Spring artefacts
-    maven { url "http://repo.springsource.org/libs-snapshot" }
+    maven { url "https://repo.springsource.org/libs-snapshot" }
     mavenLocal()
 }
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javase/6/docs/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/6/docs/api/ ([https](https://docs.oracle.com/javase/6/docs/api/) result 200).
* http://docs.spring.io/spring-data-gemfire/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data-gemfire/docs/current/api/ ([https](https://docs.spring.io/spring-data-gemfire/docs/current/api/) result 200).
* http://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html ([https](https://docs.spring.io/spring-data/commons/docs/current/api/index.html?index-all.html) result 200).
* http://docs.spring.io/spring/docs/current/javadoc-api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* http://logging.apache.org/log4j/1.2/apidocs/ with 1 occurrences migrated to:  
  https://logging.apache.org/log4j/1.2/apidocs/ ([https](https://logging.apache.org/log4j/1.2/apidocs/) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://github.com/SpringSource/spring-gemfire with 2 occurrences migrated to:  
  https://github.com/SpringSource/spring-gemfire ([https](https://github.com/SpringSource/spring-gemfire) result 301).
* http://repo.springsource.org/libs-snapshot with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://www.springsource.org/spring-gemfire with 1 occurrences migrated to:  
  https://www.springsource.org/spring-gemfire ([https](https://www.springsource.org/spring-gemfire) result 301).
* http://gemfire.docs.pivotal.io/docs-gemfire/latest/javadocs/japi/ with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/javadocs/japi/ ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/javadocs/japi/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences