### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -34,5 +34,5 @@ at spring-code-of-conduct@pivotal.io.  All complaints will be reviewed and inves
 that is deemed necessary and appropriate to the circumstances.  Maintainers are obligated to maintain confidentiality
 with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0,
-available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0,
+available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Spring Data for Pivotal GemFire
 ===============================
 
-The primary goal of the [Spring Data for Pivotal GemFire](http://projects.spring.io/spring-data-gemfire) project
+The primary goal of the [Spring Data for Pivotal GemFire](https://projects.spring.io/spring-data-gemfire) project
 is to make it easier to build highly scalable, _Spring_ powered applications using [Pivotal GemFire](https://pivotal.io/pivotal-gemfire)
 as the underlying distributed, in-memory data management platform.
 
@@ -12,15 +12,15 @@ For examples on using the _Spring Data for Pivotal GemFire_, see the
 
 # Getting Help
 
-Read the main project [website](http://projects.spring.io/spring-data-gemfire/) along with
-the [User Guide](http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/).
+Read the main project [website](https://projects.spring.io/spring-data-gemfire/) along with
+the [User Guide](https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/).
 
-Look at the source code and the [JavaDocs](http://docs.spring.io/spring-data-gemfire/docs/current/api/).
+Look at the source code and the [JavaDocs](https://docs.spring.io/spring-data-gemfire/docs/current/api/).
 
 For more detailed questions, visit [_StackOverflow_](https://stackoverflow.com/questions/tagged/spring-data-gemfire).
 
 If you are new to _Spring_ as well as _Spring Data for Pivotal GemFire_, look for information about
-[_Spring_ projects](http://spring.io/projects).
+[_Spring_ projects](https://spring.io/projects).
 
 Quick Start
 -----------
@@ -40,7 +40,7 @@ For developers in a hurry, you can download the JAR using:
 <repository>
   <id>spring-maven-snapshot</id>
   <name>Spring Maven SNAPSHOT Repository</name>
-  <url>http://repo.spring.io/snapshot</url>
+  <url>https://repo.spring.io/snapshot</url>
   <snapshots><enabled>true</enabled></snapshots>
 </repository>
 
@@ -48,7 +48,7 @@ For developers in a hurry, you can download the JAR using:
 <repository>
   <id>spring-maven-milestone</id>
   <name>Spring Maven Milestone Repository</name>
-  <url>http://repo.spring.io/milestone</url>
+  <url>https://repo.spring.io/milestone</url>
 </repository>
 ~~~~~
 
@@ -56,9 +56,9 @@ For developers in a hurry, you can download the JAR using:
 
 ~~~~~ groovy
 repositories {
-   mavenRepo name: "spring-snapshot", urls: "http://repo.spring.io/snapshot"
-   mavenRepo name: "spring-milestone", urls: "http://repo.spring.io/milestone"
-   mavenRepo name: "spring-plugins" , urls: "http://repo.spring.io/plugins-release"
+   mavenRepo name: "spring-snapshot", urls: "https://repo.spring.io/snapshot"
+   mavenRepo name: "spring-milestone", urls: "https://repo.spring.io/milestone"
+   mavenRepo name: "spring-plugins" , urls: "https://repo.spring.io/plugins-release"
 }
 
 dependencies {
@@ -73,8 +73,8 @@ dependencies {
   xmlns:gfe="http://www.springframework.org/schema/gemfire"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance
   xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd">
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd">
 
   <gfe:cache/>
 
@@ -114,9 +114,9 @@ by responding to questions and joining the debate.
 * Create [JIRA](https://jira.spring.io/browse/SGF) tickets for bugs and new features and comment and vote on the bugs
 you are interested in.
 * GitHub is for social coding. If you want to write code, we encourage contributions through pull requests
-from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way,
+from [forks of this repository](https://help.github.com/forking/). If you want to contribute code this way,
 please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on _Spring_ by [subscribing](http://spring.io/blog) to spring.io.
+* Watch for upcoming articles on _Spring_ by [subscribing](https://spring.io/blog) to spring.io.
 
 Before we accept a non-trivial patch or pull request we will need you to
 [sign the Contributor License Agreement](https://cla.pivotal.io/sign/spring). Signing the contributor’s agreement

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -3,30 +3,30 @@ Costin Leau; David Turanski; John Blum; Oliver Gierke; Jay Bryant
 :revdate: {localdate}
 :revnumber: {version}
 :apache-geode-version: 16
-:apache-geode-docs: http://geode.apache.org/docs/guide/{apache-geode-version}
-:apache-geode-javadoc: http://geode.apache.org/releases/latest/javadoc
-:apache-geode-website: http://geode.apache.org
+:apache-geode-docs: https://geode.apache.org/docs/guide/{apache-geode-version}
+:apache-geode-javadoc: https://geode.apache.org/releases/latest/javadoc
+:apache-geode-website: https://geode.apache.org
 :apache-geode-wiki: https://cwiki.apache.org/confluence/display/GEODE
 :data-store-name-symbolic: gemfire
 :data-store-name-simple: GemFire
 :data-store-name: Pivotal {data-store-name-simple}
 :data-store-version: 9.5.1
 :pivotal-gemfire-version: 95
-:pivotal-gemfire-docs: http://gemfire.docs.pivotal.io/{pivotal-gemfire-version}
-:pivotal-gemfire-javadoc: http://gemfire-{pivotal-gemfire-version}-javadocs.docs.pivotal.io/
+:pivotal-gemfire-docs: https://gemfire.docs.pivotal.io/{pivotal-gemfire-version}
+:pivotal-gemfire-javadoc: https://gemfire-{pivotal-gemfire-version}-javadocs.docs.pivotal.io/
 :pivotal-gemfire-website: https://pivotal.io/pivotal-gemfire
 :pivotal-gemfire-wiki: https://cwiki.apache.org/confluence/display/GEODE
 :sdg-acronym: SDG
 :sdg-javadoc: https://docs.spring.io/spring-data/{data-store-name-symbolic}/docs/current/api
 :sdg-name: Spring Data for {data-store-name}
 :sdg-website: https://projects.spring.io/spring-data-gemfire
-:spring-data-access-schema-location: http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+:spring-data-access-schema-location: https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
 :spring-data-access-schema-namespace: http://www.springframework.org/schema/data/gemfire
 :spring-data-commons-docs: https://docs.spring.io/spring-data/commons/docs/current/reference
 :spring-data-commons-include: ../../../../spring-data-commons/src/main/asciidoc
 :spring-data-commons-docs-html: {spring-data-commons-docs}/html
 :spring-data-commons-javadoc: https://docs.spring.io/spring-data/commons/docs/current/api
-:spring-data-schema-location: http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+:spring-data-schema-location: https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
 :spring-data-schema-namespace: http://www.springframework.org/schema/gemfire
 :spring-data-website: https://spring.io/projects/spring-data
 :spring-framework-docs: https://docs.spring.io/spring/docs/current/spring-framework-reference

--- a/src/main/asciidoc/links.adoc
+++ b/src/main/asciidoc/links.adoc
@@ -1,14 +1,14 @@
 [[sgf-links]]
 = Useful Links
 
-* http://projects.spring.io/spring-data-gemfire[{sdg-name} Project Page]
+* https://projects.spring.io/spring-data-gemfire[{sdg-name} Project Page]
 * https://github.com/spring-projects/spring-data-gemfire[{sdg-name} source code]
 * https://jira.spring.io/browse/SGF[{sdg-name} JIRA]
-* http://stackoverflow.com/questions/tagged/spring-data-gemfire[{sdg-name} on StackOverflow]
-* http://forum.spring.io/forum/spring-projects/data/gemfire[Archive of the {sdg-name} Forum on Spring IO]
+* https://stackoverflow.com/questions/tagged/spring-data-gemfire[{sdg-name} on StackOverflow]
+* https://forum.spring.io/forum/spring-projects/data/gemfire[Archive of the {sdg-name} Forum on Spring IO]
 * {x-data-store-website}[{data-store-name} Home Page]
 * {x-data-store-docs}/getting_started/book_intro.html[{data-store-name} Documentation]
 * {apache-geode-website}/community/[Apache Geode Community]
 * https://github.com/apache/geode[Apache Geode source code]
 * https://issues.apache.org/jira/projects/GEODE/issues[Apache Geode JIRA]
-* http://stackoverflow.com/questions/tagged/gemfire[{data-store-name} on StackOverflow]
+* https://stackoverflow.com/questions/tagged/gemfire[{data-store-name} on StackOverflow]

--- a/src/main/asciidoc/reference/bootstrap-annotations.adoc
+++ b/src/main/asciidoc/reference/bootstrap-annotations.adoc
@@ -1462,7 +1462,7 @@ with compression to reduce memory consumption.
 
 {data-store-name} lets you compress in memory Region values by using pluggable
 {x-data-store-javadoc}/org/apache/geode/compression/Compressor.html[`Compressors`], or different compression codecs.
-{data-store-name} uses Google's http://google.github.io/snappy/[Snappy] compression library by default.
+{data-store-name} uses Google's https://google.github.io/snappy/[Snappy] compression library by default.
 
 To enable compression, annotate the application class with `@EnableCompression`, as follows:
 
@@ -1501,7 +1501,7 @@ See the https://docs.spring.io/spring-data/gemfire/docs/current/api/org/springfr
 for more details.
 
 More details on {data-store-name} compression can be found
-http://gemfire91.docs.pivotal.io/geode/managing/region_compression.html[here].
+https://gemfire91.docs.pivotal.io/geode/managing/region_compression.html[here].
 
 [[bootstrap-annotation-config-region-off-heap]]
 === Configuring Off-Heap Memory

--- a/src/main/asciidoc/reference/bootstrap.adoc
+++ b/src/main/asciidoc/reference/bootstrap.adoc
@@ -59,7 +59,7 @@ as the following example shows:
        xmlns:gfe="{spring-data-schema-namespace}" <!--1--><!--2-->
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
     {spring-data-schema-namespace} {spring-data-schema-location} <!--3-->
 ">
 
@@ -89,7 +89,7 @@ shown earlier, as the following example shows:
        xmlns:beans="http://www.springframework.org/schema/beans" <!--2-->
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
     {spring-data-schema-namespace} {spring-data-schema-location}
 ">
 

--- a/src/main/asciidoc/reference/cache.adoc
+++ b/src/main/asciidoc/reference/cache.adoc
@@ -45,7 +45,7 @@ as follows:
 In this example, if a cache needs to be created, it uses a file named `cache.xml` located in the classpath root
 to configure it.
 
-NOTE: The configuration makes use of Spring's http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#resources[`Resource`]
+NOTE: The configuration makes use of Spring's https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#resources[`Resource`]
 abstraction to locate the file. The `Resource` abstraction lets various search patterns be used, depending on the runtime environment
 or the prefix specified (if any) in the resource location.
 
@@ -65,9 +65,9 @@ or load properties from a properties file, as follows:
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
     {spring-data-schema-namespace} {spring-data-schema-location}
-    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+    http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
   <util:properties id="gemfireProperties" location="file:/path/to/gemfire.properties"/>
@@ -129,7 +129,7 @@ or child elements, as the following listing shows:
 ----
 
 <1> Attributes support various cache options. For further information regarding anything shown in this example,
-see the {data-store-name} http://docs.pivotal.io/gemfire[product documentation].
+see the {data-store-name} https://docs.pivotal.io/gemfire[product documentation].
 The `close` attribute determines whether the cache should be closed when the Spring application context is closed.
 The default is `true`. However, for use cases in which multiple application contexts use the cache
 (common in web applications), set this value to `false`.
@@ -260,8 +260,8 @@ allowing complete configuration through the Spring container, as the following e
        xmlns:gfe="{spring-data-schema-namespace}"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
     {spring-data-schema-namespace} {spring-data-schema-location}
 ">
 
@@ -285,13 +285,13 @@ allowing complete configuration through the Spring container, as the following e
 The preceding configuration shows the `cache-server` element and the many available options.
 
 NOTE: Rather than hard-coding the port, this configuration uses Spring's
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#xsd-config-body-schemas-context[context]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#xsd-config-body-schemas-context[context]
 namespace to declare a `property-placeholder`. A
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-factory-placeholderconfigurer[property placeholder]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-factory-placeholderconfigurer[property placeholder]
 reads one or more properties files and then replaces property placeholders with values at runtime. Doing so lets administrators
 change values without having to touch the main application configuration. Spring also provides
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#expressions[SpEL]
-and an http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-environment[environment abstraction]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#expressions[SpEL]
+and an https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-environment[environment abstraction]
 to support externalization of environment-specific properties from the main codebase, easing deployment across multiple machines.
 
 NOTE: To avoid initialization problems, the `CacheServer` started by {sdg-name} starts *after* the Spring container

--- a/src/main/asciidoc/reference/cq-container.adoc
+++ b/src/main/asciidoc/reference/cq-container.adoc
@@ -90,7 +90,7 @@ between the contract and the implementation.
        xmlns:gfe="{spring-data-schema-namespace}"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
     {spring-data-schema-namespace} {spring-data-schema-location}
 ">
 

--- a/src/main/asciidoc/reference/data.adoc
+++ b/src/main/asciidoc/reference/data.adoc
@@ -55,12 +55,12 @@ Using a new data access technology requires not only accommodating a new API but
 specific to that technology.
 
 To accommodate the exception handling case, the _Spring Framework_ provides a technology agnostic and consistent
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#dao-exceptions[exception hierarchy]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#dao-exceptions[exception hierarchy]
 that abstracts the application from proprietary, and usually "checked", exceptions to a set of focused runtime
 exceptions.
 
 As mentioned in _Spring Framework's_ documentation,
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#orm-exception-translation[Exception translation]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#orm-exception-translation[Exception translation]
 can be applied transparently to your Data Access Objects (DAO) through the use of the `@Repository` annotation and AOP
 by defining a `PersistenceExceptionTranslationPostProcessor` bean. The same exception translation functionality
 is enabled when using {data-store-name} as long as the `CacheFactoryBean` is declared, e.g. using either a `<gfe:cache/>`
@@ -71,10 +71,10 @@ the Spring infrastructure and used accordingly.
 == Local, Cache Transaction Management
 
 One of the most popular features of the _Spring Framework_ is
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction[Transaction Management].
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction[Transaction Management].
 
 If you are not familiar with Spring's transaction abstraction then we strongly recommend
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction-motivation[reading]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction-motivation[reading]
 about _Spring's Transaction Management_ infrastructure as it offers a consistent _programming model_ that works
 transparently across multiple APIs and can be configured either programmatically or declaratively
 (the most popular choice).
@@ -130,12 +130,12 @@ involving more than 1 transactional resource.  Additionally, there can only be 1
 (e.g. {data-store-name}) in such an arrangement.
 
 1) First, you must complete Steps 1-4 in {data-store-name}'s documentation
-http://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html#concept_csy_vfb_wk[here].
+https://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html#concept_csy_vfb_wk[here].
 
 NOTE: #1 above is independent of your Spring [Boot] and/or [Data for {data-store-name}] application
 and must be completed successfully.
 
-2) Referring to Step 5 in {data-store-name}'s http://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html#concept_csy_vfb_wk[documentation],
+2) Referring to Step 5 in {data-store-name}'s https://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html#concept_csy_vfb_wk[documentation],
 {sdg-name}'s Annotation support will attempt to set the `GemFireCache`, {x-data-store-javadoc}/org/apache/geode/cache/GemFireCache.html#setCopyOnRead-boolean-[`copyOnRead`]
 property for you when using the `@EnableGemFireAsLastResource` annotation.
 
@@ -192,10 +192,10 @@ ClientCacheFactoryBean gemfireCache() {
 NOTE: explicitly setting the `copy-on-read` attribute or optionally the `copyOnRead` property
 really should not be necessary.
 
-3) At this point, you *skip* Steps 6-8 in {data-store-name}'s http://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html#concept_csy_vfb_wk[documentation]
+3) At this point, you *skip* Steps 6-8 in {data-store-name}'s https://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html#concept_csy_vfb_wk[documentation]
 and let _Spring Data Geode_ work its magic.  All you need do is annotate your Spring `@Configuration` class
 with {sdg-name}'s *new* `@EnableGemFireAsLastResource` annotation and a combination of Spring's
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction[Transaction Management]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction[Transaction Management]
 infrastructure and {sdg-name}'s `@EnableGemFireAsLastResource` configuration does the trick.
 
 The configuration looks like this...
@@ -241,7 +241,7 @@ The use of {sdg-name}'s `GemfireTransactionManager` is applicable only in "Local
 You configure Spring's `JtaTransactionManager` as shown above.
 
 For more details on using _Spring's Transaction Management_ with JTA,
-see http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction-application-server-integration[here].
+see https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction-application-server-integration[here].
 
 Effectively, {sdg-name}'s `@EnableGemFireAsLastResource` annotation imports configuration containing 2 Aspect
 bean definitions that handles the {data-store-name} `o.a.g.ra.GFConnectionFactory.getConnection()`
@@ -261,7 +261,7 @@ Specifically, the correct sequence of events are...
 
 This is consistent with how you, as the application developer, would code this manually if you had to use the JTA API
 + {data-store-name} API yourself, as shown in the
-{data-store-name} http://gemfire90.docs.pivotal.io/geode/developing/transactions/jca_adapter_example.html#concept_swv_z2p_wk[example].
+{data-store-name} https://gemfire90.docs.pivotal.io/geode/developing/transactions/jca_adapter_example.html#concept_swv_z2p_wk[example].
 
 Thankfully, Spring does the heavy lifting for you and all you need do after applying the appropriate configuration
 (shown above) is...
@@ -307,10 +307,10 @@ JSON : [{"id":"MSG0000000000","message":"SENT"}] ]
 ----
 
 For more details on using {data-store-name} in JTA transactions,
-see http://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html[here].
+see https://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html[here].
 
 For more details on configuring {data-store-name} as a "_Last Resource_",
-see http://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html#concept_csy_vfb_wk[here].
+see https://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html#concept_csy_vfb_wk[here].
 
 :leveloffset: +1
 
@@ -408,7 +408,7 @@ class DBLoader extends WiringDeclarableSupport implements CacheLoader {
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 ">
 
   <bean id="dataSource" ... />
@@ -440,7 +440,7 @@ one can pass in the `bean-name` parameter in the {data-store-name} configuration
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 ">
 
   <bean id="dataSource" ... />
@@ -458,13 +458,13 @@ Any format is allowed (Groovy, annotations, etc).
 === Configuration using auto-wiring and annotations
 
 By default, if no bean definition is found, `WiringDeclarableSupport` will
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-factory-autowire[autowire]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-factory-autowire[autowire]
 the declaring instance. This means that unless any dependency injection *metadata* is offered by the instance,
 the container will find the object setters and try to automatically satisfy these dependencies.
 However, a developer can also use JDK 5 annotations to provide additional information to the auto-wiring process.
 
 TIP: We strongly recommend reading the dedicated
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-annotation-config[chapter]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-annotation-config[chapter]
 in the Spring documentation for more information on the supported annotations and enabling factors.
 
 For example, the hypothetical `DBLoader` declaration above can be injected with a Spring-configured `DataSource`
@@ -497,8 +497,8 @@ class DBLoader extends WiringDeclarableSupport implements CacheLoader {
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
 ">
 
      <!-- enable annotation processing -->
@@ -517,7 +517,7 @@ the `DBLoader` code.
 == Support for the Spring Cache Abstraction
 
 {sdg-name} provides an implementation of the Spring
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache[Cache Abstraction]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache[Cache Abstraction]
 to position {data-store-name} as a _caching provider_ in Spring's caching infrastructure.
 
 To use {data-store-name} as a backing implementation, a "_caching provider_" _in Spring's Cache Abstraction_,
@@ -532,8 +532,8 @@ simply add `GemfireCacheManager` to your configuration:
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd
     {spring-data-schema-namespace} {spring-data-schema-location}
 ">
 
@@ -586,8 +586,8 @@ XML:
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd
     {spring-data-schema-namespace} {spring-data-schema-location}
 ">
 
@@ -640,4 +640,4 @@ class ApplicationConfiguration {
 Of course, you are free to choose whatever Region type you like (e.g. REPLICATE, PARTITION, LOCAL, etc).
 
 For more details on _Spring's Cache Abstraction_, again, please refer to the
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache[documentation].
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache[documentation].

--- a/src/main/asciidoc/reference/function-annotations.adoc
+++ b/src/main/asciidoc/reference/function-annotations.adoc
@@ -122,7 +122,7 @@ Note that the class itself must be registered as a Spring bean and each {data-st
 `@GemfireFunction`. In the preceding example, Spring's `@Component` annotation was used, but you can register the bean
 by using any method supported by Spring (such as XML configuration or with a Java configuration class when using
 Spring Boot). This lets the Spring container create an instance of this class and wrap it in a
-http://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/PojoFunctionWrapper.html[`PojoFunctionWrapper`].
+https://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/PojoFunctionWrapper.html[`PojoFunctionWrapper`].
 Spring creates a wrapper instance for each method annotated with `@GemfireFunction`. Each wrapper instance shares
 the same target object instance to invoke the corresponding method.
 
@@ -248,7 +248,7 @@ Function execution annotation processing in XML, insert the following element in
 
 The `function-executions` element is provided in the `gfe-data` XML namespace. The `base-package` attribute is required
 to avoid scanning the entire classpath. Additional filters can be provided as described in the Spring
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-scanning-filters[reference documentation].
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-scanning-filters[reference documentation].
 
 Optionally, you can annotate your Java configuration class as follows:
 
@@ -305,7 +305,7 @@ there are a few logistical things to keep in mind.
 
 As explained earlier in this section, and by way of example, you should typically define {data-store-name} Functions
 by using POJO classes annotated with {sdg-name}
-http://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/annotation/package-summary.html[Function annotations],
+https://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/annotation/package-summary.html[Function annotations],
 as follows:
 
 [source,java]

--- a/src/main/asciidoc/reference/gemfire-bootstrap.adoc
+++ b/src/main/asciidoc/reference/gemfire-bootstrap.adoc
@@ -40,7 +40,7 @@ The following example shows a typical, yet minimal, configuration for this class
 <?xml version="1.0" encoding="UTF-8"?>
 <cache xmlns="http://geode.apache.org/schema/cache"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+       xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
        version="1.0">
 
   <initializer>
@@ -67,7 +67,7 @@ in the classpath, as the following example shows:
 <?xml version="1.0" encoding="UTF-8"?>
 <cache xmlns="http://geode.apache.org/schema/cache"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+       xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
        version="1.0">
 
   <initializer>
@@ -151,7 +151,7 @@ the following (which comes from {sdg-acronym}'s test suite):
 <?xml version="1.0" encoding="UTF-8"?>
 <cache xmlns="http://geode.apache.org/schema/cache"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+       xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
        version="1.0">
 
   <region name="Users" refid="REPLICATE">

--- a/src/main/asciidoc/reference/indexing.adoc
+++ b/src/main/asciidoc/reference/indexing.adoc
@@ -85,7 +85,7 @@ is invoked to create a `KEY` `Index`.
 The default is `FUNCTIONAL` and results in one of the `QueryService.createIndex(..)` methods being invoked.  See the
 {sdg-name} XML schema for a full set of options.
 
-For more information on indexing in {data-store-name}, see "`http://gemfire90.docs.pivotal.io/geode/developing/query_index/query_index.html[Working with Indexes]`"
+For more information on indexing in {data-store-name}, see "`https://gemfire90.docs.pivotal.io/geode/developing/query_index/query_index.html[Working with Indexes]`"
 in {data-store-name}'s User Guide.
 
 == Defining Indexes
@@ -107,7 +107,7 @@ an `ApplicationListener` listening for the `ContextRefreshedEvent`. When fired, 
 
 Defining indexes and creating them all at once boosts speed and efficiency when creating indexes.
 
-See "`http://gemfire90.docs.pivotal.io/geode/developing/query_index/create_multiple_indexes.html[Creating Multiple Indexes at Once]`"
+See "`https://gemfire90.docs.pivotal.io/geode/developing/query_index/create_multiple_indexes.html[Creating Multiple Indexes at Once]`"
 for more details.
 
 == `IgnoreIfExists` and `Override`

--- a/src/main/asciidoc/reference/lucene.adoc
+++ b/src/main/asciidoc/reference/lucene.adoc
@@ -1,7 +1,7 @@
 [[bootstrap:lucene]]
 = Apache Lucene Integration
 
-{x-data-store-website}[{data-store-name}] integrates with http://lucene.apache.org/[Apache Lucene] to let you
+{x-data-store-website}[{data-store-name}] integrates with https://lucene.apache.org/[Apache Lucene] to let you
 index and search on data stored in {data-store-name} by using Lucene queries. Search-based queries also include
 the ability to page through query results.
 
@@ -17,7 +17,7 @@ can be created in Spring (Data for {data-store-name}) XML config as follows:
 ----
 
 Additionally, Apache Lucene allows the specification of
-http://lucene.apache.org/core/6_5_0/core/org/apache/lucene/analysis/Analyzer.html[analyzers]
+https://lucene.apache.org/core/6_5_0/core/org/apache/lucene/analysis/Analyzer.html[analyzers]
 per field and can be configured as shown in the following example:
 
 [source,xml]
@@ -175,7 +175,7 @@ The operations in the `LuceneOperations` interface match the operations provided
 {x-data-store-javadoc}/org/apache/geode/cache/lucene/LuceneQuery.html[LuceneQuery] interface.
 However, {sdg-acronym} has the added value of translating proprietary {data-store-name} or Apache Lucene `Exceptions`
 into Spring's highly consistent and expressive DAO
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#dao-exceptions[exception hierarchy],
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#dao-exceptions[exception hierarchy],
 particularly as many modern data access operations involve more than one store or repository.
 
 Additionally, {sdg-acronym}'s `LuceneOperations` interface can shield your application from interface-breaking changes
@@ -285,7 +285,7 @@ to iterate over the contents.
 
 The only restriction to the Spring Data Commons Projection infrastructure is that the projection type must be
 an interface. However, it is possible to extend the provided SDC Projection infrastructure and provide a custom
-http://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/projection/ProjectionFactory.html[`ProjectionFactory`]
+https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/projection/ProjectionFactory.html[`ProjectionFactory`]
 that uses https://github.com/cglib/cglib[CGLIB] to generate proxy classes as the projected entity.
 
 You can use `setProjectionFactory(:ProjectionFactory)` to set a custom `ProjectionFactory` on a Lucene template.

--- a/src/main/asciidoc/reference/mapping.adoc
+++ b/src/main/asciidoc/reference/mapping.adoc
@@ -276,7 +276,7 @@ when the `PdxSerializer.toData(..)` method is called during serialization.
 What happens when your entity defines a read-only property?
 
 First, it is important to understand what a "`read-only`" property is.  If you define a POJO by following the
-http://www.oracle.com/technetwork/java/javase/documentation/spec-136004.html[JavaBeans] specification (as Spring does),
+https://www.oracle.com/technetwork/java/javase/documentation/spec-136004.html[JavaBeans] specification (as Spring does),
 you might define a POJO with a read-only property, as follows:
 
 [source,java]

--- a/src/main/asciidoc/reference/region.adoc
+++ b/src/main/asciidoc/reference/region.adoc
@@ -71,7 +71,7 @@ For instance, consider the following `cache.xml` file:
 <?xml version="1.0" encoding="UTF-8"?>
 <cache xmlns="http://geode.apache.org/schema/cache"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+       xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
        version="1.0">
 
   <region name="Parent" refid="REPLICATE">
@@ -571,7 +571,7 @@ Consider the following native {data-store-name} `cache.xml` configuration file:
 <?xml version="1.0" encoding="UTF-8"?>
 <cache xmlns="http://geode.apache.org/schema/cache"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+       xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
        version="1.0">
 
   <region name="Customers" refid="REPLICATE">
@@ -610,7 +610,7 @@ metadata as follows:
        xmlns:gfe="{spring-data-schema-namespace}"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
     {spring-data-schema-namespace} {spring-data-schema-location}
 ">
 
@@ -680,7 +680,7 @@ as `REPLICATE` and exist before the cache bean is initialized (once the `<gfe:ca
 
 Based on various constraints, each Region can have an eviction policy in place for evicting data from memory.
 Currently, in {data-store-name}, eviction applies to the Least Recently Used entry (also known as
-http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used[LRU]). Evicted entries are either destroyed
+https://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used[LRU]). Evicted entries are either destroyed
 or paged to disk (referred to as "`overflow to disk`").
 
 {sdg-name} supports all eviction policies (entry count, memory, and heap usage) for PARTITION Regions, REPLICATE Regions,

--- a/src/main/asciidoc/reference/repositories.adoc
+++ b/src/main/asciidoc/reference/repositories.adoc
@@ -3,7 +3,7 @@
 
 {sdg-name} provides support for using the Spring Data Repository abstraction to easily persist entities into
 {data-store-name} along with executing queries. A general introduction to the Repository programming model
-is provided http://docs.spring.io/spring-data/data-commons/docs/current/reference/html/#repositories[here].
+is provided https://docs.spring.io/spring-data/data-commons/docs/current/reference/html/#repositories[here].
 
 [[gemfire-repositories.spring-configuration-xml]]
 == Spring XML Configuration
@@ -20,7 +20,7 @@ as the following example shows:
        xmlns:gfe-data="{spring-data-access-schema-namespace}"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
     {spring-data-access-schema-namespace} {spring-data-access-schema-location}
 ">
 
@@ -85,7 +85,7 @@ One example of where custom repository implementations are needed with {data-sto
 Joins are not supported by {sdg-acronym} Repositories. With a {data-store-name} `PARTITION` Region, the join must be
 performed on collocated `PARTITION` Regions, since {data-store-name} does not support "`distributed`" joins.
 In addition, the Equi-Join OQL Query must be performed inside a {data-store-name} Function.
-See http://gemfire91.docs.pivotal.io/geode/developing/partitioned_regions/join_query_partitioned_regions.html[here]
+See https://gemfire91.docs.pivotal.io/geode/developing/partitioned_regions/join_query_partitioned_regions.html[here]
 for more details on {data-store-name} _Equi-Join Queries_.
 
 Many other aspects of the {sdg-acronym}'s Repository infrastructure extension may be customized as well. See the

--- a/src/main/asciidoc/reference/samples.adoc
+++ b/src/main/asciidoc/reference/samples.adoc
@@ -102,9 +102,9 @@ are shutdown, the grid data is completely destroyed.
 The "`Hello World`" sample uses both Spring XML and annotations for its configuration. The initial bootstrapping configuration is
 `app-context.xml`, which includes the cache configuration defined in the `cache-context.xml` file
 and performs classpath
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-classpath-scanning[component scanning]
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-classpath-scanning[component scanning]
 for Spring
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-annotation-config[components].
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-annotation-config[components].
 
 The cache configuration defines the {data-store-name} cache, a region, and for illustrative purposes, a `CacheListener`
 that acts as a logger.

--- a/src/main/asciidoc/reference/snapshot.adoc
+++ b/src/main/asciidoc/reference/snapshot.adoc
@@ -12,7 +12,7 @@ As the {x-data-store-docs}/managing/cache_snapshots/chapter_overview.html[{data-
 snapshots let you save and subsequently reload the cached data later, which can be useful for moving data between
 environments, such as from production to a staging or test environment in order to reproduce data-related issues
 in a controlled context. You can combine {sdg-name}'s Snapshot Service support
-with http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-definition-profiles[Spring's bean definition profiles]
+with https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-definition-profiles[Spring's bean definition profiles]
 to load snapshot data specific to the environment as necessary.
 
 {sdg-name}'s support for {data-store-name}'s Snapshot Service begins with the `<gfe-data:snapshot-service>` element
@@ -187,7 +187,7 @@ to export data. However, you may want to trigger periodic, event-based snapshots
 from within your Spring application.
 
 For this purpose, {sdg-name} defines two additional Spring application events, extending Spring's
-http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/ApplicationEvent.html[`ApplicationEvent`]
+https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/ApplicationEvent.html[`ApplicationEvent`]
 class for imports and exports, respectively: `ImportSnapshotApplicationEvent` and `ExportSnapshotApplicationEvent`.
 
 The two application events can be targeted for the entire {data-store-name} cache or for individual {data-store-name}

--- a/src/main/java/org/springframework/data/gemfire/GenericRegionFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/GenericRegionFactoryBean.java
@@ -37,8 +37,8 @@ import org.apache.geode.cache.Region;
  *
  * @author John Blum
  * @see org.springframework.data.gemfire.PeerRegionFactoryBean
- * @link http://gemfire.docs.pivotal.io/latest/userguide/index.html#developing/region_options/region_types.html
- * @link http://gemfire.docs.pivotal.io/latest/userguide/index.html#developing/region_options/storage_distribution_options.html
+ * @link https://gemfire.docs.pivotal.io/latest/userguide/index.html#developing/region_options/region_types.html
+ * @link https://gemfire.docs.pivotal.io/latest/userguide/index.html#developing/region_options/storage_distribution_options.html
  * @since 1.7.0
  */
 @SuppressWarnings("unused")

--- a/src/main/java/org/springframework/data/gemfire/JndiDataSourceType.java
+++ b/src/main/java/org/springframework/data/gemfire/JndiDataSourceType.java
@@ -23,7 +23,7 @@ import org.springframework.util.StringUtils;
  * The JndiDataSourceType class is an enumeration of valid JNDI DataSource implementation types supported by GemFire.
  *
  * @author John Blum
- * @link http://gemfire.docs.pivotal.io/latest/userguide/index.html#reference/topics/cache_xml.html#jndi-binding
+ * @link https://gemfire.docs.pivotal.io/latest/userguide/index.html#reference/topics/cache_xml.html#jndi-binding
  * @since 1.7.0
  */
 @SuppressWarnings("unused")

--- a/src/main/java/org/springframework/data/gemfire/cache/config/EnableGemfireCaching.java
+++ b/src/main/java/org/springframework/data/gemfire/cache/config/EnableGemfireCaching.java
@@ -35,9 +35,9 @@ import org.springframework.context.annotation.Import;
  * @see java.lang.annotation.Retention
  * @see java.lang.annotation.Target
  * @see org.springframework.context.annotation.Import
- * @see <a href="http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache">Cache Abstraction</a>
- * @see <a href="http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache-store-configuration-gemfire">GemFire-based Cache</a>
- * @see <a href="http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#apis:spring-cache-abstraction">Support for Spring Cache Abstraction</a>
+ * @see <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache">Cache Abstraction</a>
+ * @see <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache-store-configuration-gemfire">GemFire-based Cache</a>
+ * @see <a href="https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#apis:spring-cache-abstraction">Support for Spring Cache Abstraction</a>
  * @since 2.0.0
  */
 @Target(ElementType.TYPE)

--- a/src/main/java/org/springframework/data/gemfire/cache/config/GemfireCachingConfiguration.java
+++ b/src/main/java/org/springframework/data/gemfire/cache/config/GemfireCachingConfiguration.java
@@ -41,9 +41,9 @@ import org.springframework.data.gemfire.cache.GemfireCacheManager;
  * @see org.springframework.context.annotation.Configuration
  * @see org.springframework.data.gemfire.cache.GemfireCacheManager
  * @see org.springframework.data.gemfire.cache.config.EnableGemfireCaching
- * @see <a href="http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache">Cache Abstraction</a>
- * @see <a href="http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache-store-configuration-gemfire">GemFire-based Cache</a>
- * @see <a href="http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#apis:spring-cache-abstraction">Support for Spring Cache Abstraction</a>
+ * @see <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache">Cache Abstraction</a>
+ * @see <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache-store-configuration-gemfire">GemFire-based Cache</a>
+ * @see <a href="https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#apis:spring-cache-abstraction">Support for Spring Cache Abstraction</a>
  * @since 2.0.0
  */
 @Configuration

--- a/src/main/java/org/springframework/data/gemfire/config/admin/remote/RestHttpGemfireAdminTemplate.java
+++ b/src/main/java/org/springframework/data/gemfire/config/admin/remote/RestHttpGemfireAdminTemplate.java
@@ -58,7 +58,7 @@ public class RestHttpGemfireAdminTemplate extends FunctionGemfireAdminTemplate {
 
 	protected static final String DEFAULT_HOST = "localhost";
 
-	protected static final String MANAGEMENT_REST_API_URL_TEMPLATE = "http://%1$s:%2$d/gemfire/v1/";
+	protected static final String MANAGEMENT_REST_API_URL_TEMPLATE = "https://%1$s:%2$d/gemfire/v1/";
 
 	private final RestOperations restTemplate;
 

--- a/src/main/java/org/springframework/data/gemfire/config/annotation/AbstractCacheConfiguration.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/AbstractCacheConfiguration.java
@@ -149,7 +149,7 @@ public abstract class AbstractCacheConfiguration extends AbstractAnnotationConfi
 	 *
 	 * @return a {@link Properties} object containing Pivotal GemFire/Apache Geode properties used to configure
 	 * the Pivotal GemFire/Apache Geode cache instance.
-	 * @see <a href="http://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html">Pivotal GemFire Properties</a>
+	 * @see <a href="https://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html">Pivotal GemFire Properties</a>
 	 * @see java.util.Properties
 	 * @see #locators()
 	 * @see #logLevel()

--- a/src/main/java/org/springframework/data/gemfire/config/annotation/AuthConfiguration.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/AuthConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.data.gemfire.util.PropertiesBuilder;
  * @see org.springframework.context.annotation.ImportBeanDefinitionRegistrar
  * @see org.springframework.data.gemfire.config.annotation.EnableAuth
  * @see org.springframework.data.gemfire.config.annotation.support.EmbeddedServiceConfigurationSupport
- * @see <a href="Security">http://gemfire.docs.pivotal.io/docs-gemfire/managing/security/chapter_overview.html</a>
+ * @see <a href="Security">https://gemfire.docs.pivotal.io/docs-gemfire/managing/security/chapter_overview.html</a>
  * @since 1.9.0
  */
 public class AuthConfiguration extends EmbeddedServiceConfigurationSupport {

--- a/src/main/java/org/springframework/data/gemfire/config/annotation/EnableAuth.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/EnableAuth.java
@@ -41,8 +41,8 @@ import org.springframework.context.annotation.Import;
  * @see org.apache.geode.security.Authenticator
  * @see org.springframework.context.annotation.Import
  * @see org.springframework.data.gemfire.config.annotation.AuthConfiguration
- * @see <a href="http://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authentication_overview.html">Authentication</a>
- * @see <a href="http://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authorization_overview.html">Authorization</a>
+ * @see <a href="https://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authentication_overview.html">Authentication</a>
+ * @see <a href="https://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authorization_overview.html">Authorization</a>
  * @since 1.9.0
  */
 @Target(ElementType.TYPE)

--- a/src/main/java/org/springframework/data/gemfire/config/annotation/EnableExpiration.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/EnableExpiration.java
@@ -46,9 +46,9 @@ import org.springframework.data.gemfire.expiration.TimeToLiveExpiration;
  * @see org.springframework.data.gemfire.expiration.ExpirationActionType
  * @see org.springframework.data.gemfire.expiration.IdleTimeoutExpiration
  * @see org.springframework.data.gemfire.expiration.TimeToLiveExpiration
- * @see <a href="http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:region:expiration:annotation">Annotation-based Data Expiration</a>
- * @see <a href="http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/expiration/chapter_overview.html">Pivotal GemFire Expiration</a>
- * @see <a href="http://geode.incubator.apache.org/docs/guide/developing/expiration/chapter_overview.html">Geode Expiration</a>
+ * @see <a href="https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:region:expiration:annotation">Annotation-based Data Expiration</a>
+ * @see <a href="https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/expiration/chapter_overview.html">Pivotal GemFire Expiration</a>
+ * @see <a href="https://geode.incubator.apache.org/docs/guide/developing/expiration/chapter_overview.html">Geode Expiration</a>
  * @since 1.9.0
  */
 @Target(ElementType.TYPE)
@@ -87,7 +87,7 @@ public @interface EnableExpiration {
 		 *
 		 * See the SDG Reference Guide for more details...
 		 *
-		 * @see <a href="http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:region:expiration:annotation">Annotation-based Data Expiration</a>
+		 * @see <a href="https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:region:expiration:annotation">Annotation-based Data Expiration</a>
 		 */
 		int timeout();
 
@@ -100,7 +100,7 @@ public @interface EnableExpiration {
 		 *
 		 * See the SDG Reference Guide for more details...
 		 *
-		 * @see <a href="http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:region:expiration:annotation">Annotation-based Data Expiration</a>
+		 * @see <a href="https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:region:expiration:annotation">Annotation-based Data Expiration</a>
 		 */
 		ExpirationActionType action();
 
@@ -130,8 +130,8 @@ public @interface EnableExpiration {
 	 * {@link ExpirationType} defines different types of Pivotal GemFire/Apache Geode Expiration policies such as
 	 * (Entry) Idle Timeout (TTI) and (Entry) Time to Live (TTL).
 	 *
-	 * @see <a href="http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/expiration/chapter_overview.html">Pivotal GemFire Expiration</a>
-	 * @see <a href="http://geode.incubator.apache.org/docs/guide/developing/expiration/chapter_overview.html">Geode Expiration</a>
+	 * @see <a href="https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/expiration/chapter_overview.html">Pivotal GemFire Expiration</a>
+	 * @see <a href="https://geode.incubator.apache.org/docs/guide/developing/expiration/chapter_overview.html">Geode Expiration</a>
 	 */
 	enum ExpirationType {
 

--- a/src/main/java/org/springframework/data/gemfire/config/annotation/EnableGemFireProperties.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/EnableGemFireProperties.java
@@ -32,8 +32,8 @@ import org.springframework.context.annotation.Import;
  *
  * @author John Blum
  * @see org.springframework.data.gemfire.config.annotation.GemFirePropertiesConfiguration
- * @see <a href="http://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html">Pivotal GemFire System Properties</a>
- * @see <a href="http://geode.docs.pivotal.io/docs/reference/topics/gemfire_properties.html">Geode System Properties</a>
+ * @see <a href="https://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html">Pivotal GemFire System Properties</a>
+ * @see <a href="https://geode.docs.pivotal.io/docs/reference/topics/gemfire_properties.html">Geode System Properties</a>
  * @since 1.9.0
  */
 @Target(ElementType.TYPE)
@@ -320,7 +320,7 @@ public @interface EnableGemFireProperties {
 	 *
 	 * Defaults to unset.
 	 *
-	 * @see <a href="http://geode.docs.pivotal.io/docs/developing/partitioned_regions/configuring_ha_for_pr.html">Configure High Availability for a Partitioned Region</a>
+	 * @see <a href="https://geode.docs.pivotal.io/docs/developing/partitioned_regions/configuring_ha_for_pr.html">Configure High Availability for a Partitioned Region</a>
 	 */
 	String redundancyZone() default GemFirePropertiesConfiguration.DEFAULT_REDUNDANCY_ZONE;
 
@@ -411,7 +411,7 @@ public @interface EnableGemFireProperties {
 	 *
 	 * Defaults to {@literal 100000} tombstones.
 	 *
-	 * @see <a href="http://geode.docs.pivotal.io/docs/developing/distributed_regions/how_region_versioning_works.html#topic_321B05044B6641FCAEFABBF5066BD399">How Destroy and Clear Operations Are Resolved</a>
+	 * @see <a href="https://geode.docs.pivotal.io/docs/developing/distributed_regions/how_region_versioning_works.html#topic_321B05044B6641FCAEFABBF5066BD399">How Destroy and Clear Operations Are Resolved</a>
 	 */
 	int tombstoneGcThreshold() default GemFirePropertiesConfiguration.DEFAULT_TOMBSTONE_THRESHOLD;
 

--- a/src/main/java/org/springframework/data/gemfire/config/annotation/EnableHttpService.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/EnableHttpService.java
@@ -44,7 +44,7 @@ import org.springframework.context.annotation.Import;
  * @see java.lang.annotation.Annotation
  * @see org.springframework.context.annotation.Import
  * @see org.springframework.data.gemfire.config.annotation.HttpServiceConfiguration
- * @see <a href="http://geode.docs.pivotal.io/docs/rest_apps/book_intro.html">Developing REST Applications for Apache Geode</a>
+ * @see <a href="https://geode.docs.pivotal.io/docs/rest_apps/book_intro.html">Developing REST Applications for Apache Geode</a>
  * @since 1.9.0
  */
 @Target(ElementType.TYPE)

--- a/src/main/java/org/springframework/data/gemfire/config/annotation/EnableMcast.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/EnableMcast.java
@@ -62,7 +62,7 @@ public @interface EnableMcast {
 	 *
 	 * Defaults to {@literal 239.192.81.1} for IPv4 and {@literal FF38::1234} for IPv6.
 	 *
-	 * @see <a href="http://www.iana.org/assignments/multicast-addresses">IANA chart</a>
+	 * @see <a href="https://www.iana.org/assignments/multicast-addresses">IANA chart</a>
 	 */
 	String address() default McastConfiguration.DEFAULT_MCAST_ADDRESS;
 

--- a/src/main/java/org/springframework/data/gemfire/config/annotation/HttpServiceConfiguration.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/HttpServiceConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.data.gemfire.util.PropertiesBuilder;
  * @see org.springframework.context.annotation.ImportBeanDefinitionRegistrar
  * @see org.springframework.data.gemfire.config.annotation.EnableHttpService
  * @see org.springframework.data.gemfire.config.annotation.support.EmbeddedServiceConfigurationSupport
- * @see <a href="http://geode.docs.pivotal.io/docs/rest_apps/book_intro.html">Developing REST Applications for Apache Geode</a>
+ * @see <a href="https://geode.docs.pivotal.io/docs/rest_apps/book_intro.html">Developing REST Applications for Apache Geode</a>
  * @since 1.9.0
  */
 public class HttpServiceConfiguration extends EmbeddedServiceConfigurationSupport {

--- a/src/main/java/org/springframework/data/gemfire/config/annotation/PdxConfiguration.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/PdxConfiguration.java
@@ -187,7 +187,7 @@ public class PdxConfiguration extends AbstractAnnotationConfigSupport implements
 	 * @param cacheFactoryBean {@link CacheFactoryBean} instance on which to configure PDX.
 	 * with PDX de/serialization capabilities.
 	 * @see org.springframework.data.gemfire.CacheFactoryBean
-	 * @see <a href="http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/data_serialization/gemfire_pdx_serialization.html">GemFire PDX Serialization</a>
+	 * @see <a href="https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/data_serialization/gemfire_pdx_serialization.html">GemFire PDX Serialization</a>
 	 */
 	protected void configurePdx(CacheFactoryBean cacheFactoryBean) {
 

--- a/src/main/java/org/springframework/data/gemfire/config/xml/package-info.java
+++ b/src/main/java/org/springframework/data/gemfire/config/xml/package-info.java
@@ -2,6 +2,6 @@
  * This package provides classes and components for configuring Pivotal GemFire using Spring Data's
  * XML namespace support.  See more details here...
  *
- * <a href="http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#_spring_data_gemfire_core_schema_gfe">SDG Core Schema (gfe)</a>
+ * <a href="https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#_spring_data_gemfire_core_schema_gfe">SDG Core Schema (gfe)</a>
  */
 package org.springframework.data.gemfire.config.xml;

--- a/src/main/java/org/springframework/data/gemfire/expiration/AnnotationBasedExpiration.java
+++ b/src/main/java/org/springframework/data/gemfire/expiration/AnnotationBasedExpiration.java
@@ -62,7 +62,7 @@ import org.springframework.util.ObjectUtils;
  * @see org.apache.geode.cache.ExpirationAction
  * @see org.apache.geode.cache.ExpirationAttributes
  * @see org.apache.geode.cache.Region
- * @see <a href="http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:region:expiration:annotation">Annotation-based Data Expiration</a>
+ * @see <a href="https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:region:expiration:annotation">Annotation-based Data Expiration</a>
  * @since 1.7.0
  */
 @SuppressWarnings("unused")

--- a/src/main/java/org/springframework/data/gemfire/package-info.java
+++ b/src/main/java/org/springframework/data/gemfire/package-info.java
@@ -1,7 +1,7 @@
 
 /**
  * Package providing integration of
- * <a href="http://www.gemstone.com/products/gemfire">GemFire</a>
+ * <a href="https://www.gemstone.com/products/gemfire">GemFire</a>
  * with Spring concepts.
  *
  * Contains helper classes, a template plus callback for GemFire

--- a/src/main/java/org/springframework/data/gemfire/repository/query/support/OqlKeyword.java
+++ b/src/main/java/org/springframework/data/gemfire/repository/query/support/OqlKeyword.java
@@ -24,7 +24,7 @@ import org.springframework.util.StringUtils;
  * in Pivotal GemFire's Object Query Language (OQL).
  *
  * @author John Blum
- * @see <a href="http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_additional/supported_keywords.html">Supported Keywords</a>
+ * @see <a href="https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_additional/supported_keywords.html">Supported Keywords</a>
  * @since 1.0.0
  */
 public enum OqlKeyword {

--- a/src/main/java/org/springframework/data/gemfire/support/SpringContextBootstrappingInitializer.java
+++ b/src/main/java/org/springframework/data/gemfire/support/SpringContextBootstrappingInitializer.java
@@ -62,7 +62,7 @@ import org.springframework.util.StringUtils;
  * @see org.springframework.core.io.DefaultResourceLoader
  * @see org.apache.geode.cache.Cache
  * @see org.apache.geode.cache.Declarable
- * @link http://gemfire.docs.pivotal.io/latest/userguide/index.html#basic_config/the_cache/setting_cache_initializer.html
+ * @link https://gemfire.docs.pivotal.io/latest/userguide/index.html#basic_config/the_cache/setting_cache_initializer.html
  * @link https://jira.springsource.org/browse/SGF-248
  * @since 1.4.0
  */

--- a/src/main/java/org/springframework/data/gemfire/support/SpringServerLauncherCacheProvider.java
+++ b/src/main/java/org/springframework/data/gemfire/support/SpringServerLauncherCacheProvider.java
@@ -43,7 +43,7 @@ import org.springframework.data.gemfire.GemfireUtils;
  * @see org.springframework.data.gemfire.support.SpringContextBootstrappingInitializer
  * @see org.apache.geode.distributed.ServerLauncherCacheProvider
  * @since 1.7.0
- * @link http://gemfire.docs.pivotal.io/latest/userguide/index.html#basic_config/the_cache/setting_cache_initializer.html
+ * @link https://gemfire.docs.pivotal.io/latest/userguide/index.html#basic_config/the_cache/setting_cache_initializer.html
  */
 public class SpringServerLauncherCacheProvider implements ServerLauncherCacheProvider {
 

--- a/src/main/java/org/springframework/data/gemfire/transaction/config/EnableGemfireCacheTransactions.java
+++ b/src/main/java/org/springframework/data/gemfire/transaction/config/EnableGemfireCacheTransactions.java
@@ -35,10 +35,10 @@ import org.springframework.context.annotation.Import;
  * @see java.lang.annotation.Retention
  * @see java.lang.annotation.Target
  * @see org.springframework.context.annotation.Import
- * @see <a href="http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction">Spring Transaction Management</a>
- * @see <a href="http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#apis:transaction-management">SDG Transaction Management</a>
- * @see <a href="http://gemfire.docs.pivotal.io/geode/developing/transactions/cache_transactions.html">Pivotal GemFire Cache Transactions</a>
- * @see <a href="http://geode.apache.org/docs/guide/12/developing/transactions/cache_transactions.html">Apache Geode Cache Transactions</a>
+ * @see <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#transaction">Spring Transaction Management</a>
+ * @see <a href="https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#apis:transaction-management">SDG Transaction Management</a>
+ * @see <a href="https://gemfire.docs.pivotal.io/geode/developing/transactions/cache_transactions.html">Pivotal GemFire Cache Transactions</a>
+ * @see <a href="https://geode.apache.org/docs/guide/12/developing/transactions/cache_transactions.html">Apache Geode Cache Transactions</a>
  * @since 2.0.0
  */
 @Target(ElementType.TYPE)

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,6 @@
 SPRING DATA GEMFIRE CHANGELOG
 -----------------------------
-http://www.springsource.org/spring-gemfire
+https://www.springsource.org/spring-gemfire
 =============================
 
 Changes in version 2.2.0.M2 (2019-03-07)

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -4,13 +4,13 @@ Spring Data Gemfire 2.2 M2
    ======================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternately, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/src/main/resources/org/springframework/data/gemfire/config/spring-data-gemfire-2.0.xsd
+++ b/src/main/resources/org/springframework/data/gemfire/config/spring-data-gemfire-2.0.xsd
@@ -11,11 +11,11 @@
 			version="2.0">
 	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-				schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
-				schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/gemfire"
-				schemaLocation="http://www.springframework.org/schema/gemfire/spring-gemfire.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/gemfire/spring-gemfire.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
 	<!-- -->
 	<xsd:annotation>

--- a/src/main/resources/org/springframework/data/gemfire/config/spring-data-gemfire-2.1.xsd
+++ b/src/main/resources/org/springframework/data/gemfire/config/spring-data-gemfire-2.1.xsd
@@ -12,11 +12,11 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-				schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+				schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
-				schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/gemfire"
-				schemaLocation="http://www.springframework.org/schema/gemfire/spring-gemfire.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/gemfire/spring-gemfire.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
 
 	<!-- -->

--- a/src/main/resources/readme.txt
+++ b/src/main/resources/readme.txt
@@ -1,6 +1,6 @@
 SPRING DATA GEMFIRE
 -------------------
-http://www.springsource.org/spring-gemfire
+https://www.springsource.org/spring-gemfire
 
 1. INTRODUCTION
 
@@ -15,10 +15,10 @@ details, consult the provided javadoc for specific packages and classes.
 
 3. GETTING STARTED
 
-Please see the reference documentation at http://www.springsource.org/spring-gemfire/
+Please see the reference documentation at https://www.springsource.org/spring-gemfire/
 and the Spring GemFire Examples at https://github.com/SpringSource/spring-gemfire-examples
 
 ADDITIONAL RESOURCES
-Spring Data GemFire Homepage  : http://www.springsource.org/spring-gemfire
-VMware vFabric GemFire Documentation: http://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html
-VMware vFabric GemFire product page: http://www.vmware.com/products/application-platform/vfabric-gemfire
+Spring Data GemFire Homepage  : https://www.springsource.org/spring-gemfire
+VMware vFabric GemFire Documentation: https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html
+VMware vFabric GemFire product page: https://www.vmware.com/products/application-platform/vfabric-gemfire

--- a/src/test/java/org/springframework/data/gemfire/cache/CompoundCachePutCacheEvictIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/cache/CompoundCachePutCacheEvictIntegrationTests.java
@@ -69,7 +69,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
  * @see GemfireCache#evict(Object)
  * @see GemfireCache#put(Object, Object)
- * @see <a href="http://stackoverflow.com/questions/39830488/gemfire-entrynotfoundexception-for-cacheevict">Gemfire EntryNotFoundException on @CacheEvict</a>
+ * @see <a href="https://stackoverflow.com/questions/39830488/gemfire-entrynotfoundexception-for-cacheevict">Gemfire EntryNotFoundException on @CacheEvict</a>
  * @see <a href="https://jira.spring.io/browse/SGF-539">Change GemfireCache.evict(key) to call Region.remove(key)</a>
  * @since 1.9.0
  */

--- a/src/test/java/org/springframework/data/gemfire/repository/query/GemfireQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/gemfire/repository/query/GemfireQueryMethodUnitTests.java
@@ -144,7 +144,7 @@ public class GemfireQueryMethodUnitTests {
 	}
 
 	/**
-	 * @link http://jira.spring.io/browse/SGF-112
+	 * @link https://jira.spring.io/browse/SGF-112
 	 */
 	@Test
 	public void rejectsQueryMethodWithPageableParameter() throws Exception {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://narayana.io/ (200) with 1 occurrences could not be migrated:  
   ([https](https://narayana.io/) result SSLHandshakeException).
* [ ] http://narayana.io//docs/project/index.html (200) with 1 occurrences could not be migrated:  
   ([https](https://narayana.io//docs/project/index.html) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.gemstone.com/products/gemfire (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.gemstone.com/products/gemfire ([https](https://www.gemstone.com/products/gemfire) result ConnectTimeoutException).
* [ ] http://%1 (UnknownHostException) with 1 occurrences migrated to:  
  https://%1 ([https](https://%1) result UnknownHostException).
* [ ] http://gemfire- (UnknownHostException) with 1 occurrences migrated to:  
  https://gemfire- ([https](https://gemfire-) result UnknownHostException).
* [ ] http://geode.docs.pivotal.io/docs/developing/distributed_regions/how_region_versioning_works.html (404) with 1 occurrences migrated to:  
  https://geode.docs.pivotal.io/docs/developing/distributed_regions/how_region_versioning_works.html ([https](https://geode.docs.pivotal.io/docs/developing/distributed_regions/how_region_versioning_works.html) result 404).
* [ ] http://geode.docs.pivotal.io/docs/developing/partitioned_regions/configuring_ha_for_pr.html (404) with 1 occurrences migrated to:  
  https://geode.docs.pivotal.io/docs/developing/partitioned_regions/configuring_ha_for_pr.html ([https](https://geode.docs.pivotal.io/docs/developing/partitioned_regions/configuring_ha_for_pr.html) result 404).
* [ ] http://geode.docs.pivotal.io/docs/reference/topics/gemfire_properties.html (404) with 1 occurrences migrated to:  
  https://geode.docs.pivotal.io/docs/reference/topics/gemfire_properties.html ([https](https://geode.docs.pivotal.io/docs/reference/topics/gemfire_properties.html) result 404).
* [ ] http://geode.docs.pivotal.io/docs/rest_apps/book_intro.html (404) with 2 occurrences migrated to:  
  https://geode.docs.pivotal.io/docs/rest_apps/book_intro.html ([https](https://geode.docs.pivotal.io/docs/rest_apps/book_intro.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://en.wikipedia.org/wiki/Cache_algorithms with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Cache_algorithms ([https](https://en.wikipedia.org/wiki/Cache_algorithms) result 200).
* [ ] http://geode.apache.org with 1 occurrences migrated to:  
  https://geode.apache.org ([https](https://geode.apache.org) result 200).
* [ ] http://geode.apache.org/docs/guide/ with 1 occurrences migrated to:  
  https://geode.apache.org/docs/guide/ ([https](https://geode.apache.org/docs/guide/) result 200).
* [ ] http://geode.apache.org/docs/guide/12/developing/transactions/cache_transactions.html with 1 occurrences migrated to:  
  https://geode.apache.org/docs/guide/12/developing/transactions/cache_transactions.html ([https](https://geode.apache.org/docs/guide/12/developing/transactions/cache_transactions.html) result 200).
* [ ] http://geode.apache.org/releases/latest/javadoc with 1 occurrences migrated to:  
  https://geode.apache.org/releases/latest/javadoc ([https](https://geode.apache.org/releases/latest/javadoc) result 200).
* [ ] http://geode.apache.org/schema/cache/cache-1.0.xsd with 5 occurrences migrated to:  
  https://geode.apache.org/schema/cache/cache-1.0.xsd ([https](https://geode.apache.org/schema/cache/cache-1.0.xsd) result 200).
* [ ] http://google.github.io/snappy/ with 1 occurrences migrated to:  
  https://google.github.io/snappy/ ([https](https://google.github.io/snappy/) result 200).
* [ ] http://jira.spring.io/browse/SGF-112 with 1 occurrences migrated to:  
  https://jira.spring.io/browse/SGF-112 ([https](https://jira.spring.io/browse/SGF-112) result 200).
* [ ] http://lucene.apache.org/ with 1 occurrences migrated to:  
  https://lucene.apache.org/ ([https](https://lucene.apache.org/) result 200).
* [ ] http://lucene.apache.org/core/6_5_0/core/org/apache/lucene/analysis/Analyzer.html with 1 occurrences migrated to:  
  https://lucene.apache.org/core/6_5_0/core/org/apache/lucene/analysis/Analyzer.html ([https](https://lucene.apache.org/core/6_5_0/core/org/apache/lucene/analysis/Analyzer.html) result 200).
* [ ] http://projects.spring.io/spring-data-gemfire/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-gemfire/ ([https](https://projects.spring.io/spring-data-gemfire/) result 200).
* [ ] http://spring.io/blog with 1 occurrences migrated to:  
  https://spring.io/blog ([https](https://spring.io/blog) result 200).
* [ ] http://spring.io/projects with 1 occurrences migrated to:  
  https://spring.io/projects ([https](https://spring.io/projects) result 200).
* [ ] http://stackoverflow.com/questions/39830488/gemfire-entrynotfoundexception-for-cacheevict with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/39830488/gemfire-entrynotfoundexception-for-cacheevict ([https](https://stackoverflow.com/questions/39830488/gemfire-entrynotfoundexception-for-cacheevict) result 200).
* [ ] http://stackoverflow.com/questions/tagged/gemfire with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/gemfire ([https](https://stackoverflow.com/questions/tagged/gemfire) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data-gemfire with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data-gemfire ([https](https://stackoverflow.com/questions/tagged/spring-data-gemfire) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/documentation/spec-136004.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/documentation/spec-136004.html ([https](https://www.oracle.com/technetwork/java/javase/documentation/spec-136004.html) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 13 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/data/repository/spring-repository.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/data/repository/spring-repository.xsd ([https](https://www.springframework.org/schema/data/repository/spring-repository.xsd) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.pivotal.io/gemfire with 1 occurrences migrated to:  
  https://docs.pivotal.io/gemfire ([https](https://docs.pivotal.io/gemfire) result 301).
* [ ] http://docs.spring.io/spring-data-gemfire/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data-gemfire/docs/current/api/ ([https](https://docs.spring.io/spring-data-gemfire/docs/current/api/) result 301).
* [ ] http://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/PojoFunctionWrapper.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/PojoFunctionWrapper.html ([https](https://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/PojoFunctionWrapper.html) result 301).
* [ ] http://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/annotation/package-summary.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/annotation/package-summary.html ([https](https://docs.spring.io/spring-data-gemfire/docs/current/api/org/springframework/data/gemfire/function/annotation/package-summary.html) result 301).
* [ ] http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/ with 9 occurrences migrated to:  
  https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/) result 301).
* [ ] http://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/projection/ProjectionFactory.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/projection/ProjectionFactory.html ([https](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/projection/ProjectionFactory.html) result 301).
* [ ] http://docs.spring.io/spring-data/data-commons/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-commons/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/data-commons/docs/current/reference/html/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/ApplicationEvent.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/ApplicationEvent.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/ApplicationEvent.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ with 25 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/) result 301).
* [ ] http://forum.spring.io/forum/spring-projects/data/gemfire with 1 occurrences migrated to:  
  https://forum.spring.io/forum/spring-projects/data/gemfire ([https](https://forum.spring.io/forum/spring-projects/data/gemfire) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://projects.spring.io/spring-data-gemfire with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data-gemfire ([https](https://projects.spring.io/spring-data-gemfire) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springframework.org/schema/cache/spring-cache.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/cache/spring-cache.xsd ([https](https://www.springframework.org/schema/cache/spring-cache.xsd) result 301).
* [ ] http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd ([https](https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd) result 301).
* [ ] http://www.springframework.org/schema/gemfire/spring-gemfire.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/gemfire/spring-gemfire.xsd ([https](https://www.springframework.org/schema/gemfire/spring-gemfire.xsd) result 301).
* [ ] http://www.springframework.org/schema/util/spring-util.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 301).
* [ ] http://www.springsource.org/spring-gemfire with 3 occurrences migrated to:  
  https://www.springsource.org/spring-gemfire ([https](https://www.springsource.org/spring-gemfire) result 301).
* [ ] http://www.springsource.org/spring-gemfire/ with 1 occurrences migrated to:  
  https://www.springsource.org/spring-gemfire/ ([https](https://www.springsource.org/spring-gemfire/) result 301).
* [ ] http://www.vmware.com/products/application-platform/vfabric-gemfire with 1 occurrences migrated to:  
  https://www.vmware.com/products/application-platform/vfabric-gemfire ([https](https://www.vmware.com/products/application-platform/vfabric-gemfire) result 301).
* [ ] http://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html with 1 occurrences migrated to:  
  https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html ([https](https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html) result 301).
* [ ] http://gemfire.docs.pivotal.io/ with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/ ([https](https://gemfire.docs.pivotal.io/) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/data_serialization/gemfire_pdx_serialization.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/data_serialization/gemfire_pdx_serialization.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/data_serialization/gemfire_pdx_serialization.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/expiration/chapter_overview.html with 2 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/expiration/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/expiration/chapter_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_additional/supported_keywords.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_additional/supported_keywords.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_additional/supported_keywords.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authentication_overview.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authentication_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authentication_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authorization_overview.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authorization_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/managing/security/authorization_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/managing/security/chapter_overview.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/managing/security/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/managing/security/chapter_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html with 2 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/geode/developing/transactions/cache_transactions.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/geode/developing/transactions/cache_transactions.html ([https](https://gemfire.docs.pivotal.io/geode/developing/transactions/cache_transactions.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/latest/userguide/index.html with 5 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/latest/userguide/index.html ([https](https://gemfire.docs.pivotal.io/latest/userguide/index.html) result 302).
* [ ] http://gemfire90.docs.pivotal.io/geode/developing/query_index/create_multiple_indexes.html with 1 occurrences migrated to:  
  https://gemfire90.docs.pivotal.io/geode/developing/query_index/create_multiple_indexes.html ([https](https://gemfire90.docs.pivotal.io/geode/developing/query_index/create_multiple_indexes.html) result 302).
* [ ] http://gemfire90.docs.pivotal.io/geode/developing/query_index/query_index.html with 1 occurrences migrated to:  
  https://gemfire90.docs.pivotal.io/geode/developing/query_index/query_index.html ([https](https://gemfire90.docs.pivotal.io/geode/developing/query_index/query_index.html) result 302).
* [ ] http://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html with 5 occurrences migrated to:  
  https://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html ([https](https://gemfire90.docs.pivotal.io/geode/developing/transactions/JTA_transactions.html) result 302).
* [ ] http://gemfire90.docs.pivotal.io/geode/developing/transactions/jca_adapter_example.html with 1 occurrences migrated to:  
  https://gemfire90.docs.pivotal.io/geode/developing/transactions/jca_adapter_example.html ([https](https://gemfire90.docs.pivotal.io/geode/developing/transactions/jca_adapter_example.html) result 302).
* [ ] http://gemfire91.docs.pivotal.io/geode/developing/partitioned_regions/join_query_partitioned_regions.html with 1 occurrences migrated to:  
  https://gemfire91.docs.pivotal.io/geode/developing/partitioned_regions/join_query_partitioned_regions.html ([https](https://gemfire91.docs.pivotal.io/geode/developing/partitioned_regions/join_query_partitioned_regions.html) result 302).
* [ ] http://gemfire91.docs.pivotal.io/geode/managing/region_compression.html with 1 occurrences migrated to:  
  https://gemfire91.docs.pivotal.io/geode/managing/region_compression.html ([https](https://gemfire91.docs.pivotal.io/geode/managing/region_compression.html) result 302).
* [ ] http://geode.incubator.apache.org/docs/guide/developing/expiration/chapter_overview.html with 2 occurrences migrated to:  
  https://geode.incubator.apache.org/docs/guide/developing/expiration/chapter_overview.html ([https](https://geode.incubator.apache.org/docs/guide/developing/expiration/chapter_overview.html) result 302).
* [ ] http://repo.spring.io/milestone with 2 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* [ ] http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).
* [ ] http://repo.spring.io/snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).
* [ ] http://www.iana.org/assignments/multicast-addresses with 1 occurrences migrated to:  
  https://www.iana.org/assignments/multicast-addresses ([https](https://www.iana.org/assignments/multicast-addresses) result 302).

# Ignored
These URLs were intentionally ignored.

* http://geode.apache.org/schema/cache with 10 occurrences
* http://localhost:7070/gemfire/v1/indexes with 1 occurrences
* http://localhost:7070/gemfire/v1/regions with 1 occurrences
* http://www.springframework.org/schema/beans with 30 occurrences
* http://www.springframework.org/schema/cache with 4 occurrences
* http://www.springframework.org/schema/context with 10 occurrences
* http://www.springframework.org/schema/data/gemfire with 5 occurrences
* http://www.springframework.org/schema/data/repository with 4 occurrences
* http://www.springframework.org/schema/gemfire with 11 occurrences
* http://www.springframework.org/schema/p with 4 occurrences
* http://www.springframework.org/schema/tool with 8 occurrences
* http://www.springframework.org/schema/util with 2 occurrences
* http://www.w3.org/2001/XMLSchema with 4 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 18 occurrences