### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/src/test/java/org/springframework/data/gemfire/repository/sample/CatRepository.java
+++ b/src/test/java/org/springframework/data/gemfire/repository/sample/CatRepository.java
@@ -19,11 +19,13 @@ package org.springframework.data.gemfire.repository.sample;
 import org.springframework.data.gemfire.mapping.annotation.Region;
 import org.springframework.data.gemfire.repository.GemfireRepository;
 import org.springframework.data.gemfire.repository.Query;
+import org.springframework.stereotype.Repository;
 
 /**
  * @author Stuart Williams
  * @author John Blum
  */
+@Repository
 @Region("Cats")
 public interface CatRepository extends GemfireRepository<Animal, Long> {
 


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code. 

A Spring bean in the service layer should be annotated using @Service instead of @Component annotation.
@Service annotation is a specialization of @Component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @Service is a better choice.