### PR TITLE
fix flaky test in EnableSslConfigurationDefaultContextIntegrationTests

### DIFF
--- a/src/test/java/org/springframework/data/gemfire/config/annotation/EnableSslConfigurationDefaultContextIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/config/annotation/EnableSslConfigurationDefaultContextIntegrationTests.java
@@ -71,7 +71,8 @@ public class EnableSslConfigurationDefaultContextIntegrationTests {
 
 		assertThat(gemfireProperties).isNotNull();
 		assertThat(gemfireProperties.getProperty("ssl-ciphers")).isEqualTo("FISH Scream SEAL SNOW");
-		assertThat(gemfireProperties.getProperty("ssl-enabled-components")).isEqualTo("server,gateway");
+		assertThat(gemfireProperties.getProperty("ssl-enabled-components").equals("server,gateway")
+				|| gemfireProperties.getProperty("ssl-enabled-components").equals("gateway,server")).isTrue();
 		assertThat(gemfireProperties.getProperty("ssl-default-alias")).isEqualTo("TestCert");
 		assertThat(gemfireProperties.getProperty("ssl-gateway-alias")).isEqualTo("WanCert");
 		assertThat(gemfireProperties.getProperty("ssl-keystore")).isEqualTo("/path/to/keystore.jks");


### PR DESCRIPTION
In `org/springframework/data/gemfire/config/annotation/EnableSslConfigurationDefaultContextIntegrationTests.java`, the test `sslAnnotationBasedClientConfigurationIsCorrect()` is flaky due to the non-deterministic property of HashSet() [document](https://docs.oracle.com/javase/7/docs/api/java/util/HashSet.html), which is used when creating the object of  `ConfigurableApplicationContext`. I fixed it by trying to compare two possible orders, if it satisfy either one, it will pass the test.
