### PR TITLE
fix flaky test in DefinedIndexesIntegrationTests

### DIFF
--- a/src/test/java/org/springframework/data/gemfire/config/support/DefinedIndexesIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/config/support/DefinedIndexesIntegrationTests.java
@@ -114,7 +114,8 @@ public class DefinedIndexesIntegrationTests {
 		QueryService queryService = gemfireCache.getQueryService();
 
 		List<String> expectedDefinedIndexNames = Arrays.asList(id.getName(), birthDate.getName(), name.getName());
-
+		expectedDefinedIndexNames.sort((a, b) -> (a.compareTo(b)));
+		definedIndexNames.sort((a, b) -> (a.compareTo(b)));
 		assertThat(definedIndexNames).isEqualTo(expectedDefinedIndexNames);
 		assertThat(id).isEqualTo(queryService.getIndex(people, id.getName()));
 		assertThat(birthDate).isEqualTo(queryService.getIndex(people, birthDate.getName()));


### PR DESCRIPTION
In `org/springframework/data/gemfire/config/support/DefinedIndexesIntegrationTests.java`, the test `indexesCreated()` is flaky due to the non-deterministic property of `getDeclaredMethods()` (please refer [document](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredMethods--)), which is used when creating the list  `definedIndexNames`. I fixed it by sort both the `definedIndexNames` (actual) and `expectedDefinedIndexNames` in alphabetical order, so that it is guaranteed that these two are equal to each other.
