### PR TITLE
fix flaky test in JSONRegionAdviceIntegrationTests

### DIFF
--- a/src/test/java/org/springframework/data/gemfire/repository/sample/Person.java
+++ b/src/test/java/org/springframework/data/gemfire/repository/sample/Person.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.annotation.Transient;
@@ -34,6 +35,7 @@ import org.springframework.util.ObjectUtils;
  */
 @Region("simple")
 @JsonIgnoreProperties("name")
+@JsonPropertyOrder({"address", "firstname", "id", "lastname"})
 public class Person implements Serializable {
 
 	private static final long serialVersionUID = 508843183613325255L;

--- a/src/test/java/org/springframework/data/gemfire/serialization/json/JSONRegionAdviceIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/serialization/json/JSONRegionAdviceIntegrationTests.java
@@ -27,8 +27,10 @@ import java.util.Map;
 import javax.annotation.Resource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.fasterxml.jackson.databind.SerializationConfig;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.SelectResults;
 
@@ -78,7 +80,8 @@ public class JSONRegionAdviceIntegrationTests {
 	private static String toJson(Object bean) {
 
 		try {
-			return new ObjectMapper().writeValueAsString(bean);
+			ObjectMapper mapper = new ObjectMapper().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+			return mapper.writeValueAsString(bean);
 		}
 		catch (JsonProcessingException cause) {
 			throw newIllegalArgumentException(cause, "Failed to convert object (%1$s) into JSON", bean);


### PR DESCRIPTION
In `org.springframework.data.gemfire.serialization.json.JSONRegionAdviceIntegrationTests`, the tests `objectToJSon()` , `templateFind()`, `templateFindUnique()`, `templateQuery()` are all  flaky due to the non-deterministic property of `getDeclatedFields()` (please refer [document](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--)), which is used in serialization of `org.apache.geode.cache.Region` and `com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString()`. I fixed it by adding @JsonPropertyOrder annotation to fix fix its order of properties during serialization of putting into Region, and adding `MapperFeature.SORT_PROPERTIES_ALPHABETICALLY` to make the mapper in alphabetical order.