### PR TITLE
fix flaky test in SnapshotServiceFactoryBeanIntegrationTest

### DIFF
--- a/src/test/java/org/springframework/data/gemfire/snapshot/SnapshotServiceFactoryBeanIntegrationTest.java
+++ b/src/test/java/org/springframework/data/gemfire/snapshot/SnapshotServiceFactoryBeanIntegrationTest.java
@@ -84,7 +84,10 @@ public class SnapshotServiceFactoryBeanIntegrationTest {
 				cacheSnapshotZip.getName().replaceAll("\\.", "-"));
 
 			assertThat(cacheSnapshotZipDirectory.isDirectory(), is(true));
-			assertThat(cacheSnapshotZipDirectory.listFiles(FileSystemUtils.FileOnlyFilter.INSTANCE),
+			File[] expectedSnapshots = cacheSnapshotZipDirectory.listFiles(FileSystemUtils.FileOnlyFilter.INSTANCE);
+			Arrays.sort(expectedSnapshots, (f1, f2) -> (f1.compareTo(f2)));
+			Arrays.sort(actualSnapshots, (f1, f2) -> (f1.compareTo(f2)));
+			assertThat(expectedSnapshots,
 				is(equalTo(actualSnapshots)));
 		}
 		finally {


### PR DESCRIPTION
In `org.springframework.data.gemfire.snapshot.SnapshotServiceFactoryBeanIntegrationTest`, the test `handleArchiveFileLocation()` is flaky due to the non-deterministic property of `java.io.File.listFiles()` (please refer [document](https://docs.oracle.com/javase/7/docs/api/java/io/File.html#listFiles())). I fixed it by sorting the array of `File` for both the `expectedSnapshots` and `actualSnapshots`, which eliminates the flakiness of this test.
