### PR TITLE
Fix flaky tests in CollectionUtilsUnitTests

### DIFF
--- a/src/test/java/org/springframework/data/gemfire/util/CollectionUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/gemfire/util/CollectionUtilsUnitTests.java
@@ -22,17 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -268,7 +258,7 @@ public class CollectionUtilsUnitTests {
 
 		assertThat(iterable).isNotNull();
 
-		Set<Object> set = new HashSet<>();
+		Set<Object> set = new LinkedHashSet<>();
 
 		iterable.forEach(set::add);
 

--- a/src/test/java/org/springframework/data/gemfire/util/CollectionUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/gemfire/util/CollectionUtilsUnitTests.java
@@ -206,7 +206,8 @@ public class CollectionUtilsUnitTests {
 
 		assertThat(iterable).isNotNull();
 		//assertThat(iterable).containsExactly(1, 2, 3);
-		assertThat(StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toSet()))
+		LinkedHashSet<Object> set = StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toCollection(LinkedHashSet::new));
+		assertThat(set)
 			.containsExactly(1, 2, 3);
 
 		verify(mockEnumeration, times(4)).hasMoreElements();


### PR DESCRIPTION
In `org.springframework.data.gemfire.util.CollectionUtilsUnitTests`, the tests `iterableOfEnumeration()` , `iterableOfIterator()` are all  flaky due to the non-deterministic property of `HashSet` (please refer [document](https://docs.oracle.com/javase/7/docs/api/java/util/HashSet.html)). It stores value in non-determined order, so it is possible to report exception when invoking `containsExactly()`. I fixed by changing the `HashSet` to `LinkedHashSet`, which guarantees the order of value added into the `set` and eliminates the flakiness of these two tests.
